### PR TITLE
Rename nixfmt -> nixfmt-classic

### DIFF
--- a/nix/formatting-linting.nix
+++ b/nix/formatting-linting.nix
@@ -27,7 +27,7 @@ let
     fourmolu = checkFormatting pkgs.fourmolu ../scripts/ci/run-fourmolu.sh;
     cabal-gild =
       checkFormatting pkgs.cabal-gild ../scripts/ci/run-cabal-gild.sh;
-    nixfmt = checkFormatting pkgs.nixfmt ../scripts/ci/run-nixfmt.sh;
+    nixfmt = checkFormatting pkgs.nixfmt-classic ../scripts/ci/run-nixfmt.sh;
     dos2unix = checkFormatting pkgs.dos2unix ../scripts/ci/run-dos2unix.sh;
     hlint = pkgs.runCommand "hlint" {
       buildInputs = [ pkgs.hlint ];

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,7 +5,7 @@ in hsPkgs.shellFor {
   nativeBuildInputs = [
     pkgs.cabal
     pkgs.fd
-    pkgs.nixfmt
+    pkgs.nixfmt-classic
     pkgs.dos2unix
     pkgs.cabal-gild
     pkgs.hlint


### PR DESCRIPTION
Fixes innocuous warnings when running the job locally.