### PR TITLE
feat!: support YAML config file with CLI override precedence

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,46 +5,47 @@
 module Main (main) where
 
 import Cardano.Crypto.Init (cryptoInit)
-import Data.List (intercalate)
 import Data.Void
+import Data.Yaml (decodeFileThrow)
+import GenesisSyncAccelerator.Config
+  ( PartialConfig (..)
+  , RTSFrequency (..)
+  , ResolvedOpts (..)
+  , defaultConfig
+  , showAddr
+  )
+import qualified GenesisSyncAccelerator.Config as Config
 import qualified GenesisSyncAccelerator.Diffusion as Diffusion
 import GenesisSyncAccelerator.Parsers (parseAddr)
 import qualified GenesisSyncAccelerator.RemoteStorage as RemoteStorage
 import GenesisSyncAccelerator.Tracing (Tracers (..), startResourceTracer)
-import GenesisSyncAccelerator.Types
-  ( HostAddr
-  , MaxCachedChunksCount (..)
-  , PrefetchChunksCount (..)
-  , TipRefreshInterval (..)
-  )
+import GenesisSyncAccelerator.Types (HostAddr)
 import GenesisSyncAccelerator.Util (getTopLevelConfig)
 import Main.Utf8 (withStdTerminalHandles)
 import qualified Network.Socket as Socket
 import Options.Applicative
 import System.Directory (XdgDirectory (XdgCache), getXdgDirectory)
-import System.IO (BufferMode (..), hSetBuffering, stdout)
+import System.Exit (exitFailure)
+import System.IO (BufferMode (..), hPutStrLn, hSetBuffering, stderr, stdout)
 import "contra-tracer" Control.Tracer (showTracing, stdoutTracer, traceWith)
 
 main :: IO ()
 main = withStdTerminalHandles $ do
   hSetBuffering stdout LineBuffering
   cryptoInit
-  Opts
-    { addr
-    , port
-    , configFile
-    , rtsFrequency
-    , remoteStorageCacheDir
-    , remoteStorageSrcUrl
-    , maxCachedChunks
-    , prefetchAhead
-    , tipRefreshInterval
-    } <-
-    execParser optsParser
-  let sockAddr = Socket.SockAddrInet port hostAddr
-       where
-        hostAddr = Socket.tupleToHostAddress addr
-      tracers =
+  (gsaConfigPath, cliOpts) <- execParser optsParser
+  fileOpts <- case gsaConfigPath of
+    Nothing -> pure mempty
+    Just path -> decodeFileThrow path
+  xdgCache <- getXdgDirectory XdgCache "genesis-sync-accelerator"
+  let defaults = defaultConfig{pcCacheDir = Just xdgCache}
+  opts <- case Config.resolveOpts (cliOpts <> fileOpts <> defaults) of
+    Left err -> do
+      hPutStrLn stderr $ "Error: " ++ err
+      exitFailure
+    Right o -> pure o
+  let sockAddr = resolveAddr opts
+  let tracers =
         Tracers
           { blockFetchMessageTracer = showTracing stdoutTracer
           , blockFetchEventTracer = showTracing stdoutTracer
@@ -54,150 +55,123 @@ main = withStdTerminalHandles $ do
           , handshakeTracer = showTracing stdoutTracer
           , bearerTracer = showTracing stdoutTracer
           }
-  cacheDir <- maybe (getXdgDirectory XdgCache "genesis-sync-accelerator") pure remoteStorageCacheDir
-  pInfoConfig <- getTopLevelConfig configFile
-  traceWith stdoutTracer $ "Running ImmDB server at " ++ printHost (addr, port)
-  startResourceTracer stdoutTracer (unRTSFrequency rtsFrequency)
-  let remoteCfg = RemoteStorage.RemoteStorageConfig remoteStorageSrcUrl cacheDir
+  pInfoConfig <- getTopLevelConfig (resolvedNodeConfig opts)
+  traceWith stdoutTracer $
+    "Running ImmDB server at " ++ printHost (resolvedAddr opts, resolvedPort opts)
+  startResourceTracer stdoutTracer (unRTSFrequency (resolvedRtsFrequency opts))
+  let remoteCfg = RemoteStorage.RemoteStorageConfig (resolvedSrcUrl opts) (resolvedCacheDir opts)
   absurd
     <$> Diffusion.run
       remoteCfg
-      maxCachedChunks
-      prefetchAhead
-      tipRefreshInterval
+      (resolvedMaxCachedChunks opts)
+      (resolvedPrefetchAhead opts)
+      (resolvedTipRefreshInterval opts)
       tracers
       sockAddr
       pInfoConfig
 
-newtype RTSFrequency = RTSFrequency {unRTSFrequency :: Int}
-
--- | Command-line options for the Genesis Sync Accelerator.
-data Opts = Opts
-  { addr :: HostAddr
-  -- ^ IP address to bind to.
-  , port :: Socket.PortNumber
-  -- ^ TCP port to listen on.
-  , configFile :: FilePath
-  -- ^ Path to the node configuration file.
-  , rtsFrequency :: RTSFrequency
-  -- ^ Frequency for tracing RTS statistics.
-  , remoteStorageCacheDir :: Maybe FilePath
-  -- ^ Location of Sync Accelerator cache. 'Nothing' means use the XDG default ($XDG_CACHE_HOME/genesis-sync-accelerator), or $HOME/.cache/genesis-sync-accelerator if $XDG_CACHE_HOME is not set or empty.
-  , remoteStorageSrcUrl :: String
-  -- ^ CDN URL for the Genesis Sync Accelerator.
-  , maxCachedChunks :: MaxCachedChunksCount
-  -- ^ Maximum number of chunks to keep in cache.
-  , prefetchAhead :: PrefetchChunksCount
-  -- ^ Number of chunks to prefetch ahead of current position.
-  , tipRefreshInterval :: TipRefreshInterval
-  -- ^ How often to re-fetch the tip from the CDN, in seconds.
-  }
+resolveAddr :: ResolvedOpts -> Socket.SockAddr
+resolveAddr opts = Socket.SockAddrInet (resolvedPort opts) hostAddr
+ where
+  hostAddr = Socket.tupleToHostAddress (resolvedAddr opts)
 
 printHost :: (HostAddr, Socket.PortNumber) -> String
-printHost ((a, b, c, d), port) = intercalate "." subs ++ ":" ++ show port
- where
-  subs = map show [a, b, c, d]
+printHost (addr, port) = showAddr addr ++ ":" ++ show port
 
-optsParser :: ParserInfo Opts
+optsParser :: ParserInfo (Maybe FilePath, PartialConfig)
 optsParser =
   info (helper <*> parse) $ fullDesc <> progDesc desc
  where
   desc = "Serve ImmutableDB chunks via ChainSync and BlockFetch"
 
   parse = do
-    addr <-
-      option (eitherReader parseAddr) $
-        mconcat
-          [ long "addr"
-          , help "Address to serve at"
-          , value (127, 0, 0, 1)
-          , showDefault
-          ]
-    port <-
-      option auto $
-        mconcat
-          [ long "port"
-          , help "Port to serve on"
-          , value 3001
-          , showDefault
-          ]
-    configFile <-
-      strOption $
-        mconcat
-          [ long "config"
-          , help "Path to config file, in the same format as for the node or db-analyser"
-          , metavar "PATH"
-          ]
-    rtsFrequency <-
-      RTSFrequency
-        <$> option
-          auto
-          ( mconcat
-              [ long "rts-frequency"
-              , help "Frequency (in milliseconds) to poll GHC RTS statistics"
-              , value 1000
-              , showDefault
-              ]
-          )
-    remoteStorageCacheDir <-
+    gsaConfigPath <-
+      optional $
+        strOption $
+          mconcat
+            [ long "gsa-config"
+            , help "Path to GSA YAML configuration file (can be overridden via CLI arguments)"
+            , metavar "PATH"
+            ]
+    pcAddr <-
+      optional $
+        option (eitherReader parseAddr) $
+          mconcat
+            [ long "addr"
+            , help "Address to serve at (default: 127.0.0.1)"
+            ]
+    pcPort <-
+      optional $
+        option auto $
+          mconcat
+            [ long "port"
+            , help "Port to serve on (default: 3001)"
+            ]
+    pcNodeConfig <-
+      optional $
+        strOption $
+          mconcat
+            [ long "node-config"
+            , help "Path to Cardano node config file"
+            , metavar "PATH"
+            ]
+    pcRtsFrequency <-
+      optional $
+        option auto $
+          mconcat
+            [ long "rts-frequency"
+            , help "Frequency (in milliseconds) to poll GHC RTS statistics (default: 1000)"
+            ]
+    pcCacheDir <-
       optional $
         strOption $
           mconcat
             [ long "cache-dir"
             , help
-                "Local cache directory for downloaded ImmutableDB chunks (default: $XDG_CACHE_HOME/genesis-sync-accelerator, or $HOME/.cache/genesis-sync-accelerator)"
+                "Local cache directory for downloaded ImmutableDB chunks (default: $XDG_CACHE_HOME/genesis-sync-accelerator)"
             , metavar "PATH"
             ]
-    remoteStorageSrcUrl <-
-      strOption $
-        mconcat
-          [ long "rs-src-url"
-          , help
-              "URL to a CDN serving ImmutableDB chunks (e.g. https://example.com/chain)"
-          , metavar "URL"
-          ]
-    maxCachedChunks <-
-      MaxCachedChunksCount
-        <$> option
-          auto
-          ( mconcat
-              [ long "max-cached-chunks"
-              , help "Maximum number of chunks to keep in cache"
-              , value 10
-              , showDefault
-              ]
-          )
-    prefetchAhead <-
-      PrefetchChunksCount
-        <$> option
-          auto
-          ( mconcat
-              [ long "prefetch-ahead"
-              , help "Number of chunks to prefetch ahead of current position"
-              , value 3
-              , showDefault
-              ]
-          )
-    tipRefreshInterval <-
-      TipRefreshInterval
-        <$> option
-          auto
-          ( mconcat
-              [ long "tip-refresh-interval"
-              , help "How often to re-fetch the tip from the CDN, in seconds"
-              , value 600 -- 10 minutes
-              , showDefault
-              ]
-          )
+    pcSrcUrl <-
+      optional $
+        strOption $
+          mconcat
+            [ long "rs-src-url"
+            , help
+                "URL to a CDN serving ImmutableDB chunks (e.g. https://example.com/chain)"
+            , metavar "URL"
+            ]
+    pcMaxCachedChunks <-
+      optional $
+        option auto $
+          mconcat
+            [ long "max-cached-chunks"
+            , help "Maximum number of chunks to keep in cache (default: 10)"
+            ]
+    pcPrefetchAhead <-
+      optional $
+        option auto $
+          mconcat
+            [ long "prefetch-ahead"
+            , help "Number of chunks to prefetch ahead of current position (default: 3)"
+            ]
+    pcTipRefreshInterval <-
+      optional $
+        option auto $
+          mconcat
+            [ long "tip-refresh-interval"
+            , help "How often to re-fetch the tip from the CDN, in seconds (default: 600)"
+            ]
     pure
-      Opts
-        { addr
-        , port
-        , configFile
-        , rtsFrequency
-        , remoteStorageCacheDir
-        , remoteStorageSrcUrl
-        , maxCachedChunks
-        , prefetchAhead
-        , tipRefreshInterval
-        }
+      ( gsaConfigPath
+      , PartialConfig
+          { pcAddr
+          , pcPort
+          , pcNodeConfig
+          , pcRtsFrequency
+          , pcCacheDir
+          , pcSrcUrl
+          , pcMaxCachedChunks
+          , pcPrefetchAhead
+          , pcTipRefreshInterval
+          }
+      )

--- a/genesis-sync-accelerator.cabal
+++ b/genesis-sync-accelerator.cabal
@@ -42,6 +42,7 @@ executable genesis-sync-accelerator
     "-with-rtsopts=-N -I0 -A16m"
 
   other-modules:
+    GenesisSyncAccelerator.Config
     GenesisSyncAccelerator.Diffusion
     GenesisSyncAccelerator.MiniProtocols
     GenesisSyncAccelerator.OnDemand
@@ -85,6 +86,7 @@ executable genesis-sync-accelerator
     trace-dispatcher,
     trace-resources,
     with-utf8,
+    yaml,
 
 executable immdb-get-tip
   import: common-all
@@ -106,6 +108,7 @@ library
   import: common-all
   hs-source-dirs: src
   exposed-modules:
+    GenesisSyncAccelerator.Config
     GenesisSyncAccelerator.OnDemand
     GenesisSyncAccelerator.RemoteStorage
     GenesisSyncAccelerator.Tracing
@@ -253,3 +256,21 @@ test-suite on-demand-tests
 
   other-modules:
     Test.GenesisSyncAccelerator.OnDemand.Runtime
+
+test-suite config-tests
+  import: common-all
+  main-is: Main.hs
+  hs-source-dirs: test/config
+  type: exitcode-stdio-1.0
+  ghc-options:
+    -threaded
+    -rtsopts
+
+  build-depends:
+    genesis-sync-accelerator,
+    tasty,
+    tasty-hunit,
+    yaml,
+
+  other-modules:
+    Test.GenesisSyncAccelerator.Config

--- a/src/GenesisSyncAccelerator/Config.hs
+++ b/src/GenesisSyncAccelerator/Config.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GenesisSyncAccelerator.Config
+  ( PartialConfig (..)
+  , RTSFrequency (..)
+  , ResolvedOpts (..)
+  , defaultConfig
+  , resolveOpts
+  , showAddr
+  ) where
+
+import Control.Applicative ((<|>))
+import Data.Aeson (FromJSON (..), withObject, (.:?))
+import Data.Aeson.Types (Parser)
+import Data.List (intercalate, sort)
+import Data.Maybe (fromMaybe, isNothing)
+import GenesisSyncAccelerator.Parsers (parseAddr)
+import GenesisSyncAccelerator.Types
+  ( HostAddr
+  , MaxCachedChunksCount (..)
+  , PrefetchChunksCount (..)
+  , TipRefreshInterval (..)
+  )
+import qualified Network.Socket as Socket
+import Numeric.Natural (Natural)
+
+-- | Resolved options after merging CLI and config file.
+data ResolvedOpts = ResolvedOpts
+  { resolvedAddr :: HostAddr
+  , resolvedPort :: Socket.PortNumber
+  , resolvedNodeConfig :: FilePath
+  , resolvedRtsFrequency :: RTSFrequency
+  , resolvedCacheDir :: FilePath
+  , resolvedSrcUrl :: String
+  , resolvedMaxCachedChunks :: MaxCachedChunksCount
+  , resolvedPrefetchAhead :: PrefetchChunksCount
+  , resolvedTipRefreshInterval :: TipRefreshInterval
+  }
+
+newtype RTSFrequency = RTSFrequency {unRTSFrequency :: Int}
+
+-- | Partial configuration. Used for both CLI options and the config file.
+-- All fields are optional; merging uses left-biased @('<>')@.
+data PartialConfig = PartialConfig
+  { pcAddr :: Maybe HostAddr
+  , pcPort :: Maybe Socket.PortNumber
+  , pcNodeConfig :: Maybe FilePath
+  , pcRtsFrequency :: Maybe Int
+  , pcCacheDir :: Maybe FilePath
+  , pcSrcUrl :: Maybe String
+  , pcMaxCachedChunks :: Maybe Natural
+  , pcPrefetchAhead :: Maybe Natural
+  , pcTipRefreshInterval :: Maybe Natural
+  }
+
+-- | Left-biased merge: the first argument wins when both sides are 'Just'.
+instance Semigroup PartialConfig where
+  a <> b =
+    PartialConfig
+      { pcAddr = pcAddr a <|> pcAddr b
+      , pcPort = pcPort a <|> pcPort b
+      , pcNodeConfig = pcNodeConfig a <|> pcNodeConfig b
+      , pcRtsFrequency = pcRtsFrequency a <|> pcRtsFrequency b
+      , pcCacheDir = pcCacheDir a <|> pcCacheDir b
+      , pcSrcUrl = pcSrcUrl a <|> pcSrcUrl b
+      , pcMaxCachedChunks = pcMaxCachedChunks a <|> pcMaxCachedChunks b
+      , pcPrefetchAhead = pcPrefetchAhead a <|> pcPrefetchAhead b
+      , pcTipRefreshInterval = pcTipRefreshInterval a <|> pcTipRefreshInterval b
+      }
+
+instance Monoid PartialConfig where
+  mempty =
+    PartialConfig
+      { pcAddr = Nothing
+      , pcPort = Nothing
+      , pcNodeConfig = Nothing
+      , pcRtsFrequency = Nothing
+      , pcCacheDir = Nothing
+      , pcSrcUrl = Nothing
+      , pcMaxCachedChunks = Nothing
+      , pcPrefetchAhead = Nothing
+      , pcTipRefreshInterval = Nothing
+      }
+
+-- | Default values for all optional configuration fields.
+-- Does not include 'pcCacheDir' since the XDG default requires IO;
+-- the caller should set it before passing to 'resolveOpts'.
+defaultConfig :: PartialConfig
+defaultConfig =
+  mempty
+    { pcAddr = Just (127, 0, 0, 1)
+    , pcPort = Just 3001
+    , pcRtsFrequency = Just 1000
+    , pcMaxCachedChunks = Just 10
+    , pcPrefetchAhead = Just 3
+    , pcTipRefreshInterval = Just 600
+    }
+
+instance FromJSON PartialConfig where
+  parseJSON = withObject "PartialConfig" $ \o -> do
+    addr <- traverse parseAddrJSON =<< o .:? "addr"
+    port <- fmap fromIntegral <$> (o .:? "port" :: Parser (Maybe Int))
+    PartialConfig addr port
+      <$> o .:? "node-config"
+      <*> o .:? "rts-frequency"
+      <*> o .:? "cache-dir"
+      <*> o .:? "rs-src-url"
+      <*> o .:? "max-cached-chunks"
+      <*> o .:? "prefetch-ahead"
+      <*> o .:? "tip-refresh-interval"
+   where
+    parseAddrJSON s = case parseAddr s of
+      Right a -> pure a
+      Left err -> fail $ "Invalid addr: " ++ err
+
+-- | Unwrap a fully-merged 'PartialConfig' into 'ResolvedOpts'.
+-- Every field must be 'Just' (either set explicitly or filled by 'defaultConfig').
+-- Reports all missing fields at once rather than stopping at the first.
+resolveOpts :: PartialConfig -> Either String ResolvedOpts
+resolveOpts pc =
+  case missing of
+    [] ->
+      Right
+        ResolvedOpts
+          { resolvedAddr = grab (pcAddr pc)
+          , resolvedPort = grab (pcPort pc)
+          , resolvedNodeConfig = grab (pcNodeConfig pc)
+          , resolvedRtsFrequency = RTSFrequency $ grab (pcRtsFrequency pc)
+          , resolvedCacheDir = grab (pcCacheDir pc)
+          , resolvedSrcUrl = grab (pcSrcUrl pc)
+          , resolvedMaxCachedChunks = MaxCachedChunksCount $ grab (pcMaxCachedChunks pc)
+          , resolvedPrefetchAhead = PrefetchChunksCount $ grab (pcPrefetchAhead pc)
+          , resolvedTipRefreshInterval = TipRefreshInterval $ grab (pcTipRefreshInterval pc)
+          }
+    _ ->
+      Left $
+        "Missing required option(s): "
+          ++ intercalate ", " (sort missing)
+          ++ " (set via CLI or config file)"
+ where
+  grab = fromMaybe (error "unreachable: field checked but missing")
+  missing =
+    [name | (name, True) <- checks]
+  checks =
+    [ ("addr", isNothing (pcAddr pc))
+    , ("port", isNothing (pcPort pc))
+    , ("node-config", isNothing (pcNodeConfig pc))
+    , ("rts-frequency", isNothing (pcRtsFrequency pc))
+    , ("cache-dir", isNothing (pcCacheDir pc))
+    , ("rs-src-url", isNothing (pcSrcUrl pc))
+    , ("max-cached-chunks", isNothing (pcMaxCachedChunks pc))
+    , ("prefetch-ahead", isNothing (pcPrefetchAhead pc))
+    , ("tip-refresh-interval", isNothing (pcTipRefreshInterval pc))
+    ]
+
+showAddr :: HostAddr -> String
+showAddr (a, b, c, d) = intercalate "." $ map show [a, b, c, d]

--- a/test/config/Main.hs
+++ b/test/config/Main.hs
@@ -1,0 +1,14 @@
+module Main (main) where
+
+import qualified Test.GenesisSyncAccelerator.Config
+import Test.Tasty (TestTree, defaultMain, testGroup)
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests =
+  testGroup
+    "config"
+    [ Test.GenesisSyncAccelerator.Config.tests
+    ]

--- a/test/config/Test/GenesisSyncAccelerator/Config.hs
+++ b/test/config/Test/GenesisSyncAccelerator/Config.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.GenesisSyncAccelerator.Config (tests) where
+
+import Data.List (isInfixOf)
+import Data.Yaml (ParseException, decodeEither', decodeThrow)
+import GenesisSyncAccelerator.Config
+  ( PartialConfig (..)
+  , ResolvedOpts (..)
+  , defaultConfig
+  , resolveOpts
+  )
+import GenesisSyncAccelerator.Types
+  ( MaxCachedChunksCount (..)
+  , PrefetchChunksCount (..)
+  , TipRefreshInterval (..)
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+
+tests :: TestTree
+tests =
+  testGroup
+    "resolveOpts"
+    [ testDefaults
+    , testCliOverridesConfigFile
+    , testConfigFileFillsGaps
+    , testMissingRequired
+    , testInvalidConfigAddr
+    , testYamlParsing
+    ]
+
+-- | Required fields provided, everything else defaults.
+testDefaults :: TestTree
+testDefaults = testCase "defaults apply when only required fields are set" $ do
+  let pc =
+        mempty{pcNodeConfig = Just "/node.json", pcSrcUrl = Just "http://cdn", pcCacheDir = Just "/cache"}
+  case resolveOpts (pc <> defaultConfig) of
+    Left err -> fail $ "unexpected error: " ++ err
+    Right opts -> do
+      resolvedAddr opts @?= (127, 0, 0, 1)
+      resolvedPort opts @?= 3001
+      resolvedMaxCachedChunks opts @?= MaxCachedChunksCount 10
+      resolvedPrefetchAhead opts @?= PrefetchChunksCount 3
+      resolvedTipRefreshInterval opts @?= TipRefreshInterval 600
+
+-- | CLI values take precedence over config file values (left-biased merge).
+testCliOverridesConfigFile :: TestTree
+testCliOverridesConfigFile = testCase "CLI overrides config file values" $ do
+  let cli =
+        mempty
+          { pcNodeConfig = Just "/cli-node.json"
+          , pcSrcUrl = Just "http://cli-cdn"
+          , pcPort = Just 4000
+          , pcMaxCachedChunks = Just 20
+          , pcCacheDir = Just "/cli-cache"
+          }
+      cf =
+        mempty
+          { pcNodeConfig = Just "/cf-node.json"
+          , pcSrcUrl = Just "http://cf-cdn"
+          , pcPort = Just 5000
+          , pcMaxCachedChunks = Just 30
+          , pcCacheDir = Just "/cf-cache"
+          }
+  case resolveOpts (cli <> cf <> defaultConfig) of
+    Left err -> fail $ "unexpected error: " ++ err
+    Right opts -> do
+      resolvedNodeConfig opts @?= "/cli-node.json"
+      resolvedSrcUrl opts @?= "http://cli-cdn"
+      resolvedPort opts @?= 4000
+      resolvedMaxCachedChunks opts @?= MaxCachedChunksCount 20
+      resolvedCacheDir opts @?= "/cli-cache"
+
+-- | Config file values are used when CLI omits them.
+testConfigFileFillsGaps :: TestTree
+testConfigFileFillsGaps = testCase "config file fills in when CLI is absent" $ do
+  let cf =
+        mempty
+          { pcNodeConfig = Just "/cf-node.json"
+          , pcSrcUrl = Just "http://cf-cdn"
+          , pcPort = Just 7000
+          , pcAddr = Just (10, 0, 0, 1)
+          , pcPrefetchAhead = Just 5
+          , pcCacheDir = Just "/cf-cache"
+          }
+  case resolveOpts (cf <> defaultConfig) of
+    Left err -> fail $ "unexpected error: " ++ err
+    Right opts -> do
+      resolvedNodeConfig opts @?= "/cf-node.json"
+      resolvedSrcUrl opts @?= "http://cf-cdn"
+      resolvedPort opts @?= 7000
+      resolvedAddr opts @?= (10, 0, 0, 1)
+      resolvedPrefetchAhead opts @?= PrefetchChunksCount 5
+
+-- | Missing required fields produce errors.
+testMissingRequired :: TestTree
+testMissingRequired =
+  testGroup
+    "missing required fields"
+    [ testCase "missing node-config" $ do
+        let pc = mempty{pcSrcUrl = Just "http://cdn", pcCacheDir = Just "/cache"}
+        assertLeft "node-config" $ resolveOpts (pc <> defaultConfig)
+    , testCase "missing rs-src-url" $ do
+        let pc = mempty{pcNodeConfig = Just "/node.json", pcCacheDir = Just "/cache"}
+        assertLeft "rs-src-url" $ resolveOpts (pc <> defaultConfig)
+    , testCase "missing both" $ do
+        let result = resolveOpts defaultConfig
+        assertLeft "node-config" result
+        assertLeft "rs-src-url" result
+        assertLeft "cache-dir" result
+    ]
+
+-- | Invalid addr in config file YAML is caught during parsing.
+testInvalidConfigAddr :: TestTree
+testInvalidConfigAddr = testCase "invalid addr in YAML is a parse error" $ do
+  let yaml = "addr: not.an.ip\nnode-config: /n.json\nrs-src-url: http://cdn\n"
+  case decodeEither' yaml :: Either ParseException PartialConfig of
+    Left _ -> pure () -- parse failure, as expected
+    Right _ -> fail "expected YAML parse failure for invalid addr"
+
+-- | YAML round-trip: a small config parses into the expected PartialConfig.
+testYamlParsing :: TestTree
+testYamlParsing = testCase "YAML parses into PartialConfig" $ do
+  let yaml =
+        "node-config: /path/to/node.json\n\
+        \rs-src-url: http://cdn.example.com/chain\n\
+        \port: 3002\n\
+        \max-cached-chunks: 25\n\
+        \addr: 192.168.1.1\n"
+  case decodeThrow yaml of
+    Nothing -> fail "YAML parsing returned Nothing"
+    Just pc -> do
+      pcNodeConfig pc @?= Just "/path/to/node.json"
+      pcSrcUrl pc @?= Just "http://cdn.example.com/chain"
+      pcPort pc @?= Just 3002
+      pcMaxCachedChunks pc @?= Just 25
+      pcAddr pc @?= Just (192, 168, 1, 1)
+      pcRtsFrequency pc @?= Nothing
+      pcCacheDir pc @?= Nothing
+      pcPrefetchAhead pc @?= Nothing
+      pcTipRefreshInterval pc @?= Nothing
+
+-- Helpers
+
+assertLeft :: String -> Either String a -> IO ()
+assertLeft expected (Left err) =
+  assertBool
+    ("expected error containing " ++ show expected ++ ", got: " ++ err)
+    (expected `isInfixOf` err)
+assertLeft expected (Right _) =
+  fail $ "expected Left containing " ++ show expected ++ ", got Right"

--- a/test/integration/config.yaml
+++ b/test/integration/config.yaml
@@ -1,0 +1,13 @@
+# GSA integration test configuration.
+# This file also serves as an example of the full config file format.
+# Only max-cached-chunks and rts-frequency are actually used from here;
+max-cached-chunks: 25
+rts-frequency: 2000
+
+# The integration test overrides node-config, rs-src-url, port, and
+# cache-dir via CLI flags, which take precedence over this file.
+node-config: config/config.json
+rs-src-url: http://127.0.0.1:8780
+addr: 127.0.0.1
+port: 8781
+cache-dir: /tmp/gsa-cache

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -13,15 +13,17 @@ start_cdn() {
   echo $!
 }
 
-# start_accelerator <cache_dir> <config> <cdn_url> <port> <max_chunks> <log_file>
+# start_accelerator <gsa_config> <node_config> <cdn_url> <port> <cache_dir> <log_file> [extra_flags...]
 start_accelerator() {
-  local cache_dir="$1" config="$2" cdn_url="$3" port="$4" max_chunks="$5" log_file="$6"
+  local gsa_config="$1" node_config="$2" cdn_url="$3" port="$4" cache_dir="$5" log_file="$6"
+  shift 6
   stdbuf -oL ${GSA:-genesis-sync-accelerator} \
-    --config "$config" \
+    --gsa-config "$gsa_config" \
+    --node-config "$node_config" \
     --rs-src-url "$cdn_url" \
-    --cache-dir "$cache_dir" \
     --port "$port" \
-    --max-cached-chunks "$max_chunks" \
+    --cache-dir "$cache_dir" \
+    "$@" \
     +RTS -T -RTS \
     >"$log_file" 2>&1 &
   echo $!

--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -36,8 +36,7 @@ CDN_PORT="${CDN_PORT:-8780}"
 ACCEL_PORT="${ACCEL_PORT:-8781}"
 CONSUMER_PORT="${CONSUMER_PORT:-8782}"
 MIN_CHUNKS="${MIN_CHUNKS:-20}"
-MAX_CACHED_CHUNKS=25
-RTS_FREQUENCY="${RTS_FREQUENCY:-2000}"  # Accelerator RTS event log frequency in ms.
+GSA_CONFIG="$SCRIPT_DIR/config.yaml"
 POLL_INTERVAL=5
 LOG_TAIL_LINES=50
 SOURCE_DB="${DB_DIR:-$SCRIPT_DIR/test-data/source-db}"
@@ -162,7 +161,7 @@ fi
 echo ""
 echo "${BOLD}=== Starting accelerator ===${NC}"
 
-ACCEL_PID=$(start_accelerator "$ACCEL_CACHE" "$CONFIG" "http://127.0.0.1:${CDN_PORT}" "$ACCEL_PORT" "$MAX_CACHED_CHUNKS" "$TMPDIR/accelerator.log")
+ACCEL_PID=$(start_accelerator "$GSA_CONFIG" "$CONFIG" "http://127.0.0.1:${CDN_PORT}" "$ACCEL_PORT" "$ACCEL_CACHE" "$TMPDIR/accelerator.log")
 PIDS+=($ACCEL_PID)
 
 wait_for_port "$ACCEL_PORT" 15 "Accelerator"


### PR DESCRIPTION
BREAKING CHANGE: --config is renamed to --node-config, and --node-config and --rs-src-url are no longer unconditionally required on the CLI (they can now be provided via the config file instead).