### PR TITLE
fix: use find over ls to avoid 0 error

### DIFF
--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -224,7 +224,7 @@ while (( ELAPSED < CONSUMER_TIMEOUT )); do
   done
 
   # Hook C: Richer progress in demo mode
-  CACHE_COUNT=$(ls "$ACCEL_CACHE"/*.chunk 2>/dev/null | wc -l)
+  CACHE_COUNT=$(find "$ACCEL_CACHE" -maxdepth 1 -name '*.chunk' | wc -l)
   if demo_is_active; then
     echo "  ${ELAPSED}/${CONSUMER_TIMEOUT}s — ${CONSUMER_BLOCKS}/${EXPECTED_IMMUTABLE_BLOCKS_COUNT} blocks | Cache: ${CACHE_COUNT} chunks"
   else


### PR DESCRIPTION
ls returns non-zero when no items are listed, find doesn't do this.


Inspired by this failure: https://github.com/tweag/genesis-sync-accelerator/actions/runs/24502487642/job/71612566424