### PR TITLE
fix CI?

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   integration-test:
     runs-on: [self-hosted, Linux, X64, tweag-infra]
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v6

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
               pkgs.jq
               pkgs.iproute2
               pkgs.tmux
+              pkgs.util-linux
             ];
           };
         };


### PR DESCRIPTION
https://github.com/tweag/genesis-sync-accelerator/actions/runs/24668886307/job/72133814450

We ran into an issue where CI seemed to succeed even though it failed. This PR addresses two issues.
1. it ensures that the pipeline fails if the job fails by removing continue-on-error
2. It ensures setsid is available in the devShell where the integration tests are run