### PR TITLE
Hardening types related to exponential backoff

### DIFF
--- a/src/GenesisSyncAccelerator/Config.hs
+++ b/src/GenesisSyncAccelerator/Config.hs
@@ -19,6 +19,7 @@ import GenesisSyncAccelerator.Types
   ( HostAddr
   , MaxCachedChunksCount (..)
   , PrefetchChunksCount (..)
+  , RetryCount (..)
   , TipRefreshInterval (..)
   )
 import qualified Network.Socket as Socket
@@ -35,7 +36,7 @@ data ResolvedOpts = ResolvedOpts
   , resolvedMaxCachedChunks :: MaxCachedChunksCount
   , resolvedPrefetchAhead :: PrefetchChunksCount
   , resolvedTipRefreshInterval :: TipRefreshInterval
-  , resolvedMaxRetries :: Int
+  , resolvedMaxRetries :: RetryCount
   , resolvedBaseDelay :: Int
   }
 
@@ -53,7 +54,7 @@ data PartialConfig = PartialConfig
   , pcMaxCachedChunks :: Maybe Natural
   , pcPrefetchAhead :: Maybe Natural
   , pcTipRefreshInterval :: Maybe Natural
-  , pcMaxRetries :: Maybe Int
+  , pcMaxRetries :: Maybe RetryCount
   , pcBaseDelay :: Maybe Int
   }
 
@@ -102,7 +103,7 @@ defaultConfig =
     , pcMaxCachedChunks = Just 10
     , pcPrefetchAhead = Just 3
     , pcTipRefreshInterval = Just 600
-    , pcMaxRetries = Just 5
+    , pcMaxRetries = Just (RetryCount 5)
     , pcBaseDelay = Just 100000
     }
 

--- a/src/GenesisSyncAccelerator/Config.hs
+++ b/src/GenesisSyncAccelerator/Config.hs
@@ -19,8 +19,10 @@ import GenesisSyncAccelerator.Types
   ( HostAddr
   , MaxCachedChunksCount (..)
   , PrefetchChunksCount (..)
+  , RetryBaseDelay
   , RetryCount (..)
   , TipRefreshInterval (..)
+  , asRetryBaseDelay
   )
 import qualified Network.Socket as Socket
 import Numeric.Natural (Natural)
@@ -37,7 +39,7 @@ data ResolvedOpts = ResolvedOpts
   , resolvedPrefetchAhead :: PrefetchChunksCount
   , resolvedTipRefreshInterval :: TipRefreshInterval
   , resolvedMaxRetries :: RetryCount
-  , resolvedBaseDelay :: Int
+  , resolvedBaseDelay :: RetryBaseDelay
   }
 
 newtype RTSFrequency = RTSFrequency {unRTSFrequency :: Int}
@@ -55,7 +57,7 @@ data PartialConfig = PartialConfig
   , pcPrefetchAhead :: Maybe Natural
   , pcTipRefreshInterval :: Maybe Natural
   , pcMaxRetries :: Maybe RetryCount
-  , pcBaseDelay :: Maybe Int
+  , pcBaseDelay :: Maybe Natural
   }
 
 -- | Left-biased merge: the first argument wins when both sides are 'Just'.
@@ -145,7 +147,7 @@ resolveOpts pc =
           , resolvedPrefetchAhead = PrefetchChunksCount $ grab (pcPrefetchAhead pc)
           , resolvedTipRefreshInterval = TipRefreshInterval $ grab (pcTipRefreshInterval pc)
           , resolvedMaxRetries = grab (pcMaxRetries pc)
-          , resolvedBaseDelay = grab (pcBaseDelay pc)
+          , resolvedBaseDelay = asRetryBaseDelay $ grab (pcBaseDelay pc)
           }
     _ ->
       Left $

--- a/src/GenesisSyncAccelerator/RemoteStorage.hs
+++ b/src/GenesisSyncAccelerator/RemoteStorage.hs
@@ -43,6 +43,7 @@ import GenesisSyncAccelerator.Tracing
   , TraceDownloadFailure (..)
   , TraceRemoteStorageEvent (..)
   )
+import GenesisSyncAccelerator.Types (RetryCount (..))
 import Network.HTTP.Client hiding (Manager)
 import qualified Network.HTTP.Client as HTTP (Manager, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -57,7 +58,7 @@ data RemoteStorageConfig = RemoteStorageConfig
   -- ^ The root URL of the CDN (e.g., "https://cdn.cardano.org/mainnet/immutable"), without trailing slash.
   , rscDstDir :: FilePath
   -- ^ Local directory where the downloaded chunks should be stored.
-  , rscMaxRetries :: Int
+  , rscMaxRetries :: RetryCount
   -- ^ Maximum number of retries for transient failures.
   , rscBaseDelay :: Int
   -- ^ Base delay in microseconds for exponential backoff.
@@ -72,7 +73,7 @@ newRemoteStorageEnv url dir =
     RemoteStorageConfig
       { rscSrcUrl = url
       , rscDstDir = dir
-      , rscMaxRetries = 5
+      , rscMaxRetries = RetryCount 5
       , rscBaseDelay = 100000
       }
 
@@ -151,6 +152,9 @@ fetchTipInfo tracer env =
     env
     "tip.json"
 
+incrementRetryCount :: RetryCount -> RetryCount
+incrementRetryCount (RetryCount n) = RetryCount (n + 1)
+
 -- | Retry an action with exponential backoff if it fails with a transient error.
 withRetry ::
   MonadIO m =>
@@ -159,7 +163,7 @@ withRetry ::
   String ->
   m (Either TraceDownloadFailure a) ->
   m (Either TraceDownloadFailure a)
-withRetry tr cfg url action = go 0
+withRetry tr cfg url action = go (RetryCount 0)
  where
   maxRetries = rscMaxRetries cfg
   baseDelay = rscBaseDelay cfg
@@ -173,10 +177,11 @@ withRetry tr cfg url action = go 0
   retry n lastRes
     | n >= maxRetries = pure (Left lastRes)
     | otherwise = do
-        let delay = baseDelay * (2 ^ n)
-        traceWith tr $ TraceDownloadRetry url (n + 1) delay
+        let delay = baseDelay * (2 ^ unRetryCount n)
+            n' = incrementRetryCount n
+        traceWith tr $ TraceDownloadRetry url n' delay
         liftIO $ threadDelay delay
-        go (n + 1)
+        go n'
 
 tryFileRequest ::
   forall m result.

--- a/src/GenesisSyncAccelerator/RemoteStorage.hs
+++ b/src/GenesisSyncAccelerator/RemoteStorage.hs
@@ -18,9 +18,9 @@ module GenesisSyncAccelerator.RemoteStorage
   , RemoteStorageConfig (..)
   , RemoteStorageEnv (..)
   , RemoteTipInfo (..)
-  , TraceRemoteStorageEvent (..)
   , RemoteStorageTracer
   , TraceDownloadFailure (..)
+  , TraceRemoteStorageEvent (..)
   , getFileName
   , toSuffix
   , FileType (..)
@@ -43,7 +43,12 @@ import GenesisSyncAccelerator.Tracing
   , TraceDownloadFailure (..)
   , TraceRemoteStorageEvent (..)
   )
-import GenesisSyncAccelerator.Types (RetryCount (..))
+import GenesisSyncAccelerator.Types
+  ( RetryBaseDelay
+  , RetryCount (..)
+  , asRetryBaseDelay
+  , getRetryDelay
+  )
 import Network.HTTP.Client hiding (Manager)
 import qualified Network.HTTP.Client as HTTP (Manager, newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -60,8 +65,8 @@ data RemoteStorageConfig = RemoteStorageConfig
   -- ^ Local directory where the downloaded chunks should be stored.
   , rscMaxRetries :: RetryCount
   -- ^ Maximum number of retries for transient failures.
-  , rscBaseDelay :: Int
-  -- ^ Base delay in microseconds for exponential backoff.
+  , rscBaseDelay :: RetryBaseDelay
+  -- ^ Base delay for exponential backoff.
   }
   deriving (Eq, Show)
 
@@ -74,7 +79,7 @@ newRemoteStorageEnv url dir =
       { rscSrcUrl = url
       , rscDstDir = dir
       , rscMaxRetries = RetryCount 5
-      , rscBaseDelay = 100000
+      , rscBaseDelay = asRetryBaseDelay 100000 -- 100ms in microseconds
       }
 
 -- | Create a 'RemoteStorageEnv' from an existing 'RemoteStorageConfig'.
@@ -177,10 +182,10 @@ withRetry tr cfg url action = go (RetryCount 0)
   retry n lastRes
     | n >= maxRetries = pure (Left lastRes)
     | otherwise = do
-        let delay = baseDelay * (2 ^ unRetryCount n)
+        let delay = getRetryDelay baseDelay n
             n' = incrementRetryCount n
         traceWith tr $ TraceDownloadRetry url n' delay
-        liftIO $ threadDelay delay
+        liftIO $ threadDelay $ fromIntegral delay
         go n'
 
 tryFileRequest ::

--- a/src/GenesisSyncAccelerator/Tracing.hs
+++ b/src/GenesisSyncAccelerator/Tracing.hs
@@ -24,6 +24,7 @@ import Control.Monad.Class.MonadAsync (link)
 import Data.Text (unpack)
 import Data.Word (Word64)
 import GHC.Conc (labelThread, myThreadId)
+import GenesisSyncAccelerator.Types (RetryCount)
 import Network.Mux (BearerTrace, WithBearer)
 import Network.Socket (SockAddr)
 import Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
@@ -75,7 +76,7 @@ data TraceRemoteStorageEvent
   | -- | Retrying download after failure.
     TraceDownloadRetry
       String
-      Int
+      RetryCount
       -- | URL, retry count, delay in microseconds
       Int
   | -- | Starting download of tip metadata.

--- a/src/GenesisSyncAccelerator/Tracing.hs
+++ b/src/GenesisSyncAccelerator/Tracing.hs
@@ -27,6 +27,7 @@ import GHC.Conc (labelThread, myThreadId)
 import GenesisSyncAccelerator.Types (RetryCount)
 import Network.Mux (BearerTrace, WithBearer)
 import Network.Socket (SockAddr)
+import Numeric.Natural
 import Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
   ( TraceBlockFetchServerEvent
   )
@@ -78,7 +79,7 @@ data TraceRemoteStorageEvent
       String
       RetryCount
       -- | URL, retry count, delay in microseconds
-      Int
+      Natural
   | -- | Starting download of tip metadata.
     TraceTipFetchStart !String
   | -- | Successfully fetched tip metadata.

--- a/src/GenesisSyncAccelerator/Types.hs
+++ b/src/GenesisSyncAccelerator/Types.hs
@@ -5,10 +5,13 @@ module GenesisSyncAccelerator.Types
   ( HostAddr
   , MaxCachedChunksCount (..)
   , PrefetchChunksCount (..)
+  , RetryBaseDelay
   , RetryCount (..)
   , StandardBlock
   , StandardTopLevelConfig
   , TipRefreshInterval (..)
+  , asRetryBaseDelay
+  , getRetryDelay
   ) where
 
 import Data.Aeson (FromJSON)
@@ -28,6 +31,16 @@ newtype MaxCachedChunksCount = MaxCachedChunksCount Natural
 -- | How many chunks ahead of the current to fetch in advance
 newtype PrefetchChunksCount = PrefetchChunksCount Natural
   deriving (Eq, Show)
+
+-- | The base delay (for exponential backoff) for retrying a failed operation
+newtype RetryBaseDelay = RetryBaseDelay {unRetryBaseDelay :: Natural}
+  deriving (Eq, FromJSON, Ord, Show)
+
+asRetryBaseDelay :: Natural -> RetryBaseDelay
+asRetryBaseDelay = RetryBaseDelay
+
+getRetryDelay :: RetryBaseDelay -> RetryCount -> Natural
+getRetryDelay (RetryBaseDelay base) (RetryCount n) = base * (2 ^ n)
 
 -- | Count of number of retries for some operation
 newtype RetryCount = RetryCount {unRetryCount :: Natural}

--- a/src/GenesisSyncAccelerator/Types.hs
+++ b/src/GenesisSyncAccelerator/Types.hs
@@ -1,12 +1,17 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Domain-specific type wrappers and aliases
 module GenesisSyncAccelerator.Types
   ( HostAddr
   , MaxCachedChunksCount (..)
   , PrefetchChunksCount (..)
+  , RetryCount (..)
   , StandardBlock
   , StandardTopLevelConfig
   , TipRefreshInterval (..)
   ) where
 
+import Data.Aeson (FromJSON)
 import Data.Word (Word8)
 import Numeric.Natural
 import Ouroboros.Consensus.Cardano.Block (CardanoBlock)
@@ -23,6 +28,10 @@ newtype MaxCachedChunksCount = MaxCachedChunksCount Natural
 -- | How many chunks ahead of the current to fetch in advance
 newtype PrefetchChunksCount = PrefetchChunksCount Natural
   deriving (Eq, Show)
+
+-- | Count of number of retries for some operation
+newtype RetryCount = RetryCount {unRetryCount :: Natural}
+  deriving (Eq, FromJSON, Ord, Read, Show)
 
 -- | The block type typically used across the codebase
 type StandardBlock = CardanoBlock StandardCrypto

--- a/src/GenesisSyncAccelerator/Types.hs
+++ b/src/GenesisSyncAccelerator/Types.hs
@@ -20,10 +20,6 @@ type HostAddr = (Word8, Word8, Word8, Word8)
 newtype MaxCachedChunksCount = MaxCachedChunksCount Natural
   deriving (Eq, Show)
 
--- | How often to refresh the tip from the CDN, in seconds.
-newtype TipRefreshInterval = TipRefreshInterval Natural
-  deriving (Eq, Show)
-
 -- | How many chunks ahead of the current to fetch in advance
 newtype PrefetchChunksCount = PrefetchChunksCount Natural
   deriving (Eq, Show)
@@ -33,3 +29,7 @@ type StandardBlock = CardanoBlock StandardCrypto
 
 -- | The type of main configuration object used across the codebase
 type StandardTopLevelConfig = TopLevelConfig StandardBlock
+
+-- | How often to refresh the tip from the CDN, in seconds.
+newtype TipRefreshInterval = TipRefreshInterval Natural
+  deriving (Eq, Show)

--- a/src/gsa-testlib/Test/GenesisSyncAccelerator/Utilities.hs
+++ b/src/gsa-testlib/Test/GenesisSyncAccelerator/Utilities.hs
@@ -23,7 +23,7 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 import GenesisSyncAccelerator.OnDemand (OnDemandConfig (..))
 import GenesisSyncAccelerator.RemoteStorage (FileType (..), RemoteStorageConfig (..), getFileName)
-import GenesisSyncAccelerator.Types (RetryCount (..), StandardBlock)
+import GenesisSyncAccelerator.Types (RetryCount (..), StandardBlock, asRetryBaseDelay)
 import GenesisSyncAccelerator.Util (fpToHasFS, getTopLevelConfig)
 import Network.Wai.Application.Static (defaultFileServerSettings, staticApp)
 import Network.Wai.Handler.Warp (Port, testWithApplication)
@@ -106,7 +106,7 @@ mkFullConfig PartialOnDemandConfig{..} (ConfigFile configFile) (TmpDir tmpdir) p
             { rscSrcUrl = getLocalUrl port
             , rscDstDir = tmpdir
             , rscMaxRetries = RetryCount 0 -- Disable retries in tests by default
-            , rscBaseDelay = 0
+            , rscBaseDelay = asRetryBaseDelay 0
             }
       , odcTracer = nullTracer
       , odcChunkInfo = podcChunkInfo

--- a/src/gsa-testlib/Test/GenesisSyncAccelerator/Utilities.hs
+++ b/src/gsa-testlib/Test/GenesisSyncAccelerator/Utilities.hs
@@ -23,7 +23,7 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 import GenesisSyncAccelerator.OnDemand (OnDemandConfig (..))
 import GenesisSyncAccelerator.RemoteStorage (FileType (..), RemoteStorageConfig (..), getFileName)
-import GenesisSyncAccelerator.Types (StandardBlock)
+import GenesisSyncAccelerator.Types (RetryCount (..), StandardBlock)
 import GenesisSyncAccelerator.Util (fpToHasFS, getTopLevelConfig)
 import Network.Wai.Application.Static (defaultFileServerSettings, staticApp)
 import Network.Wai.Handler.Warp (Port, testWithApplication)
@@ -105,7 +105,7 @@ mkFullConfig PartialOnDemandConfig{..} (ConfigFile configFile) (TmpDir tmpdir) p
           RemoteStorageConfig
             { rscSrcUrl = getLocalUrl port
             , rscDstDir = tmpdir
-            , rscMaxRetries = 0 -- Disable retries in tests by default
+            , rscMaxRetries = RetryCount 0 -- Disable retries in tests by default
             , rscBaseDelay = 0
             }
       , odcTracer = nullTracer

--- a/test/config/Test/GenesisSyncAccelerator/Config.hs
+++ b/test/config/Test/GenesisSyncAccelerator/Config.hs
@@ -13,6 +13,7 @@ import GenesisSyncAccelerator.Config
 import GenesisSyncAccelerator.Types
   ( MaxCachedChunksCount (..)
   , PrefetchChunksCount (..)
+  , RetryCount (..)
   , TipRefreshInterval (..)
   )
 import Test.Tasty (TestTree, testGroup)
@@ -44,7 +45,7 @@ testDefaults = testCase "defaults apply when only required fields are set" $ do
       resolvedMaxCachedChunks opts @?= MaxCachedChunksCount 10
       resolvedPrefetchAhead opts @?= PrefetchChunksCount 3
       resolvedTipRefreshInterval opts @?= TipRefreshInterval 600
-      resolvedMaxRetries opts @?= 5
+      resolvedMaxRetries opts @?= RetryCount 5
       resolvedBaseDelay opts @?= 100000
       resolvedSrcUrl opts @?= "http://cdn"
 
@@ -58,7 +59,7 @@ testCliOverridesConfigFile = testCase "CLI overrides config file values" $ do
           , pcPort = Just 4000
           , pcMaxCachedChunks = Just 20
           , pcCacheDir = Just "/cli-cache"
-          , pcMaxRetries = Just 10
+          , pcMaxRetries = Just (RetryCount 10)
           , pcBaseDelay = Just 50000
           }
       cf =
@@ -68,7 +69,7 @@ testCliOverridesConfigFile = testCase "CLI overrides config file values" $ do
           , pcPort = Just 5000
           , pcMaxCachedChunks = Just 30
           , pcCacheDir = Just "/cf-cache"
-          , pcMaxRetries = Just 15
+          , pcMaxRetries = Just (RetryCount 15)
           , pcBaseDelay = Just 75000
           }
   case resolveOpts (cli <> cf <> defaultConfig) of
@@ -79,7 +80,7 @@ testCliOverridesConfigFile = testCase "CLI overrides config file values" $ do
       resolvedPort opts @?= 4000
       resolvedMaxCachedChunks opts @?= MaxCachedChunksCount 20
       resolvedCacheDir opts @?= "/cli-cache"
-      resolvedMaxRetries opts @?= 10
+      resolvedMaxRetries opts @?= RetryCount 10
       resolvedBaseDelay opts @?= 50000
 
 -- | Config file values are used when CLI omits them.
@@ -148,7 +149,7 @@ testYamlParsing = testCase "YAML parses into PartialConfig" $ do
       pcPort pc @?= Just 3002
       pcMaxCachedChunks pc @?= Just 25
       pcAddr pc @?= Just (192, 168, 1, 1)
-      pcMaxRetries pc @?= Just 7
+      pcMaxRetries pc @?= Just (RetryCount 7)
       pcBaseDelay pc @?= Just 200000
       pcRtsFrequency pc @?= Nothing
       pcCacheDir pc @?= Nothing

--- a/test/config/Test/GenesisSyncAccelerator/Config.hs
+++ b/test/config/Test/GenesisSyncAccelerator/Config.hs
@@ -15,6 +15,7 @@ import GenesisSyncAccelerator.Types
   , PrefetchChunksCount (..)
   , RetryCount (..)
   , TipRefreshInterval (..)
+  , asRetryBaseDelay
   )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase, (@?=))
@@ -46,7 +47,7 @@ testDefaults = testCase "defaults apply when only required fields are set" $ do
       resolvedPrefetchAhead opts @?= PrefetchChunksCount 3
       resolvedTipRefreshInterval opts @?= TipRefreshInterval 600
       resolvedMaxRetries opts @?= RetryCount 5
-      resolvedBaseDelay opts @?= 100000
+      resolvedBaseDelay opts @?= asRetryBaseDelay 100000
       resolvedSrcUrl opts @?= "http://cdn"
 
 -- | CLI values take precedence over config file values (left-biased merge).
@@ -81,7 +82,7 @@ testCliOverridesConfigFile = testCase "CLI overrides config file values" $ do
       resolvedMaxCachedChunks opts @?= MaxCachedChunksCount 20
       resolvedCacheDir opts @?= "/cli-cache"
       resolvedMaxRetries opts @?= RetryCount 10
-      resolvedBaseDelay opts @?= 50000
+      resolvedBaseDelay opts @?= asRetryBaseDelay 50000
 
 -- | Config file values are used when CLI omits them.
 testConfigFileFillsGaps :: TestTree

--- a/test/download/Test/GenesisSyncAccelerator/Download/Retry.hs
+++ b/test/download/Test/GenesisSyncAccelerator/Download/Retry.hs
@@ -17,7 +17,7 @@ import Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..))
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 import qualified System.IO.Temp as Temp
-import Test.GenesisSyncAccelerator.Utilities (tracerToFile)
+import Test.GenesisSyncAccelerator.Utilities (getLocalUrl, tracerToFile)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase)
 
@@ -48,7 +48,7 @@ testRetrySuccess = Temp.withSystemTempDirectory "retry-test-success" $ \tmp -> d
   testWithApplication (pure $ mkRetryApp counter maxFailures) $ \port -> do
     let cfg =
           RemoteStorageConfig
-            { rscSrcUrl = "http://localhost:" ++ show port
+            { rscSrcUrl = getLocalUrl port
             , rscDstDir = cacheDir
             , rscMaxRetries = 3
             , rscBaseDelay = 1000 -- 1ms for fast tests
@@ -77,7 +77,7 @@ testRetryFailure = Temp.withSystemTempDirectory "retry-test-failure" $ \tmp -> d
   testWithApplication (pure app) $ \port -> do
     let cfg =
           RemoteStorageConfig
-            { rscSrcUrl = "http://localhost:" ++ show port
+            { rscSrcUrl = getLocalUrl port
             , rscDstDir = cacheDir
             , rscMaxRetries = maxRetries
             , rscBaseDelay = 1000

--- a/test/download/Test/GenesisSyncAccelerator/Download/Retry.hs
+++ b/test/download/Test/GenesisSyncAccelerator/Download/Retry.hs
@@ -10,6 +10,7 @@ import GenesisSyncAccelerator.RemoteStorage
   , downloadChunk
   , newRemoteStorageEnvWithConfig
   )
+import GenesisSyncAccelerator.Types (RetryCount (..))
 import Network.HTTP.Types (status200, status503)
 import Network.Wai (Application, responseLBS)
 import Network.Wai.Handler.Warp (testWithApplication)
@@ -50,7 +51,7 @@ testRetrySuccess = Temp.withSystemTempDirectory "retry-test-success" $ \tmp -> d
           RemoteStorageConfig
             { rscSrcUrl = getLocalUrl port
             , rscDstDir = cacheDir
-            , rscMaxRetries = 3
+            , rscMaxRetries = RetryCount 3
             , rscBaseDelay = 1000 -- 1ms for fast tests
             }
     env <- newRemoteStorageEnvWithConfig cfg
@@ -68,7 +69,7 @@ testRetryFailure = Temp.withSystemTempDirectory "retry-test-failure" $ \tmp -> d
   let cacheDir = tmp </> "cache"
       logFile = tmp </> "retry-fail.log"
       tracer = tracerToFile logFile
-      maxRetries = 2
+      maxRetries = RetryCount 2
   createDirectoryIfMissing True cacheDir
 
   -- Use a fixed response that always fails
@@ -92,13 +93,14 @@ testRetryFailure = Temp.withSystemTempDirectory "retry-test-failure" $ \tmp -> d
         let retryLines = filter (Text.isInfixOf "TraceDownloadRetry") (Text.lines logContent)
         -- Since downloadChunk downloads 3 files and our app fails EVERY request,
         -- each of the 3 files will be retried maxRetries times.
-        let totalRetries = maxRetries * 3
+        let expTotalRetries = unRetryCount maxRetries * 3
+            obsTotalRetries = length retryLines
         assertBool
           ( "Expected exactly "
-              ++ show totalRetries
+              ++ show expTotalRetries
               ++ " retries, but got "
-              ++ show (length retryLines)
+              ++ show obsTotalRetries
               ++ ". Log:\n"
               ++ Text.unpack logContent
           )
-          (length retryLines == totalRetries)
+          (obsTotalRetries == fromIntegral expTotalRetries)

--- a/test/download/Test/GenesisSyncAccelerator/Download/Retry.hs
+++ b/test/download/Test/GenesisSyncAccelerator/Download/Retry.hs
@@ -10,7 +10,7 @@ import GenesisSyncAccelerator.RemoteStorage
   , downloadChunk
   , newRemoteStorageEnvWithConfig
   )
-import GenesisSyncAccelerator.Types (RetryCount (..))
+import GenesisSyncAccelerator.Types (RetryCount (..), asRetryBaseDelay)
 import Network.HTTP.Types (status200, status503)
 import Network.Wai (Application, responseLBS)
 import Network.Wai.Handler.Warp (testWithApplication)
@@ -52,7 +52,7 @@ testRetrySuccess = Temp.withSystemTempDirectory "retry-test-success" $ \tmp -> d
             { rscSrcUrl = getLocalUrl port
             , rscDstDir = cacheDir
             , rscMaxRetries = RetryCount 3
-            , rscBaseDelay = 1000 -- 1ms for fast tests
+            , rscBaseDelay = asRetryBaseDelay 1000 -- 1 millisecond for fast tests
             }
     env <- newRemoteStorageEnvWithConfig cfg
     res <- downloadChunk tracer env (ChunkNo 1)
@@ -81,7 +81,7 @@ testRetryFailure = Temp.withSystemTempDirectory "retry-test-failure" $ \tmp -> d
             { rscSrcUrl = getLocalUrl port
             , rscDstDir = cacheDir
             , rscMaxRetries = maxRetries
-            , rscBaseDelay = 1000
+            , rscBaseDelay = asRetryBaseDelay 1000 -- 1 millisecond for fast tests
             }
     env <- newRemoteStorageEnvWithConfig cfg
     res <- downloadChunk tracer env (ChunkNo 1)

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -30,7 +30,11 @@ import GenesisSyncAccelerator.OnDemand
   )
 import qualified GenesisSyncAccelerator.OnDemand as OnDemand
 import GenesisSyncAccelerator.RemoteStorage (FileType (..), RemoteStorageConfig (..), getFileName)
-import GenesisSyncAccelerator.Types (MaxCachedChunksCount (..), PrefetchChunksCount (..))
+import GenesisSyncAccelerator.Types
+  ( MaxCachedChunksCount (..)
+  , PrefetchChunksCount (..)
+  , RetryCount (..)
+  )
 import GenesisSyncAccelerator.Util (fpToHasFS)
 import Ouroboros.Consensus.Block (StandardHash)
 import Ouroboros.Consensus.Block.Abstract
@@ -1025,7 +1029,12 @@ makeRuntimeWithNullRemoteAndNullLogging (TmpDir tmp) chunkInfo chunkedBlocks =
   OnDemand.newOnDemandRuntime $
     OnDemandConfig
       { odcRemote =
-          RemoteStorageConfig{rscSrcUrl = getLocalUrl (1 + 2 ^ (16 :: Int)), rscDstDir = tmp}
+          RemoteStorageConfig
+            { rscSrcUrl = getLocalUrl (1 + 2 ^ (16 :: Int))
+            , rscDstDir = tmp
+            , rscMaxRetries = RetryCount 0
+            , rscBaseDelay = 0
+            }
       , odcTracer = nullTracer
       , odcChunkInfo = chunkInfo
       , odcHasFS = fpToHasFS tmp

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -34,6 +34,7 @@ import GenesisSyncAccelerator.Types
   ( MaxCachedChunksCount (..)
   , PrefetchChunksCount (..)
   , RetryCount (..)
+  , asRetryBaseDelay
   )
 import GenesisSyncAccelerator.Util (fpToHasFS)
 import Ouroboros.Consensus.Block (StandardHash)
@@ -1033,7 +1034,7 @@ makeRuntimeWithNullRemoteAndNullLogging (TmpDir tmp) chunkInfo chunkedBlocks =
             { rscSrcUrl = getLocalUrl (1 + 2 ^ (16 :: Int))
             , rscDstDir = tmp
             , rscMaxRetries = RetryCount 0
-            , rscBaseDelay = 0
+            , rscBaseDelay = asRetryBaseDelay 1000
             }
       , odcTracer = nullTracer
       , odcChunkInfo = chunkInfo


### PR DESCRIPTION
Ideally, we'd use something like `refined` + `dimensional` (see #66), but this keeps it simple for now, as such a refactor is probably better done repo-wide rather than for one or two new fields.