### PR TITLE
Two bug fixes

### DIFF
--- a/genesis-sync-accelerator.cabal
+++ b/genesis-sync-accelerator.cabal
@@ -257,6 +257,7 @@ test-suite on-demand-tests
     serialise,
     strict-checked-vars,
     tasty,
+    tasty-hunit,
     tasty-quickcheck,
     temporary,
     text,

--- a/src/GenesisSyncAccelerator/MiniProtocols.hs
+++ b/src/GenesisSyncAccelerator/MiniProtocols.hs
@@ -19,13 +19,12 @@ module GenesisSyncAccelerator.MiniProtocols (genesisSyncAccelerator) where
 
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
-import Control.Monad (when)
+import Control.Monad (when, (>=>))
 import Control.Monad.IO.Class (MonadIO)
 import Control.ResourceRegistry
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import Data.Functor ((<&>))
-import Data.List (find)
 import qualified Data.Map.Strict as Map
 import Data.Void (Void)
 import GHC.Generics (Generic)
@@ -275,9 +274,43 @@ chainSyncServer tr onDemand blockComponent _registry = ChainSyncServer $ do
 
         followerClose = ImmutableDB.iteratorClose =<< readTVarIO varIterator
 
+        -- On-chain test: open an inclusive iterator and peek the first entry.
+        -- Same idiom as ouroboros-consensus's 'Impl.Follower.forward', which
+        -- uses 'streamAfterPoint' as its existence check. A hash mismatch
+        -- throws 'IllegalStreamOperation', which we catch as "not on chain".
+        isPointInChain GenesisPoint = pure True
+        isPointInChain (BlockPoint slot hash) =
+          try probe >>= \case
+            Left (_ :: OnDemand.IllegalStreamOperation blk) -> pure False
+            Right ok -> pure ok
+         where
+          probe =
+            bracket
+              ( OnDemand.onDemandIteratorFrom
+                  onDemand
+                  blockComponent
+                  (StreamFromInclusive (RealPoint slot hash))
+              )
+              ImmutableDB.iteratorClose
+              $ ImmutableDB.iteratorNext >=> \case
+                ImmutableDB.IteratorExhausted -> pure False
+                ImmutableDB.IteratorResult a ->
+                  pure $ case ChainDB.point a of
+                    BlockPoint pSlot pHash -> pSlot == slot && pHash == hash
+                    GenesisPoint -> False
+
+        findUsableIntersection mbTip = go
+         where
+          go [] = pure Nothing
+          go (pt : rest)
+            | not (withinTip mbTip pt) = go rest
+            | otherwise = do
+                onChain <- isPointInChain pt
+                if onChain then pure (Just pt) else go rest
+
         followerForward pts = do
           mbTip <- atomically $ OnDemand.readOnDemandTip onDemand
-          case find (withinTip mbTip) pts of
+          findUsableIntersection mbTip pts >>= \case
             Nothing -> pure Nothing
             Just pt ->
               OnDemand.onDemandIteratorFrom onDemand blockComponent (StreamFromExclusive pt) >>= \iterator -> do

--- a/src/GenesisSyncAccelerator/OnDemand.hs
+++ b/src/GenesisSyncAccelerator/OnDemand.hs
@@ -36,14 +36,12 @@ import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, putMVar,
 import Control.Exception (Exception, throw)
 import Control.Monad (unless, void)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Bifunctor as Bifunctor
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (traverse_)
 import Data.List (delete, foldl', genericSplitAt, genericTake, partition)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as Map
-import Data.Maybe (listToMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -317,24 +315,19 @@ mkOnDemandIterator
                   , cs
                   , \c es ->
                       if isLast c
-                        then
-                          checkEntryMatch
-                            odcChunkInfo
-                            toSlot
-                            toHash
-                            (\entries -> if null entries then Nothing else Just (last entries))
-                            (takeWhile (\(WithBlockSize _ e) -> getEntrySlot odcChunkInfo e <= toSlot) es)
+                        then truncateAtUpperBound odcChunkInfo toSlot toHash es
                         else Right es
                   , isLast
                   )
         applyFrom :: ChunkNo -> [SizedEntry blk] -> Either (IllegalStreamOperation blk) [SizedEntry blk]
-        applyFrom c es = if c == NEL.head chunks then finalizeFrom <$> validateFrom (getFrom es) else Right es
+        applyFrom c es = if c == NEL.head chunks then finalizeFrom <$> validateFrom es else Right es
          where
-          dropInit fromSlot = dropWhile $ \(WithBlockSize _ e) -> getEntrySlot odcChunkInfo e < fromSlot
-          (getFrom, validateFrom, finalizeFrom) = case from of
-            StreamFromExclusive GenesisPoint -> (id, Right, id)
-            StreamFromExclusive (BlockPoint fromSlot fromHash) -> (dropInit fromSlot, checkEntryMatch odcChunkInfo fromSlot fromHash listToMaybe, drop 1)
-            StreamFromInclusive (RealPoint fromSlot fromHash) -> (dropInit fromSlot, checkEntryMatch odcChunkInfo fromSlot fromHash listToMaybe, id)
+          (validateFrom, finalizeFrom) = case from of
+            StreamFromExclusive GenesisPoint -> (Right, id)
+            StreamFromExclusive (BlockPoint fromSlot fromHash) ->
+              (dropUntilLowerBound odcChunkInfo fromSlot fromHash, drop 1)
+            StreamFromInclusive (RealPoint fromSlot fromHash) ->
+              (dropUntilLowerBound odcChunkInfo fromSlot fromHash, id)
 
     -- Initialize state for chunks left to process and the current chunk iterator.
     varChunks <- newTVarIO $ NEL.toList chunks
@@ -696,21 +689,49 @@ deriving instance (StandardHash blk, Typeable blk) => Exception (IllegalStreamOp
 
 type SizedEntry blk = WithBlockSize (Entry blk)
 
-checkEntryMatch ::
+-- | Drop entries until the (slot, hash) match. Searching by hash, not
+-- position, is required because Byron EBBs and the first main block of an
+-- epoch share a slot.
+dropUntilLowerBound ::
   Eq (HeaderHash blk) =>
   ChunkInfo ->
   SlotNo ->
   HeaderHash blk ->
-  ([SizedEntry blk] -> Maybe (SizedEntry blk)) ->
   [SizedEntry blk] ->
   Either (IllegalStreamOperation blk) [SizedEntry blk]
-checkEntryMatch ci s h getE es =
-  Bifunctor.first (StreamBoundNotFound (s, h)) $
-    maybe
-      (Left Nothing)
-      ( \(WithBlockSize _ e) -> if (getEntrySlot ci e, headerHash e) == (s, h) then Right es else Left (Just e)
-      )
-      (getE es)
+dropUntilLowerBound ci fromSlot fromHash = go Nothing
+ where
+  -- 'mbNear' = most recent same-slot non-match, reported in StreamBoundNotFound.
+  go mbNear [] = Left (StreamBoundNotFound (fromSlot, fromHash) mbNear)
+  go mbNear (e@(WithBlockSize _ entry) : rest) =
+    case compare (getEntrySlot ci entry) fromSlot of
+      LT -> go mbNear rest
+      EQ
+        | headerHash entry == fromHash -> Right (e : rest)
+        | otherwise -> go (Just entry) rest
+      GT -> Left (StreamBoundNotFound (fromSlot, fromHash) (Just entry))
+
+-- | Truncate at the (slot, hash) match. As with 'dropUntilLowerBound',
+-- searching by hash (not @last . takeWhile slot <= toSlot@) is required
+-- because Byron EBBs and the first main block of an epoch share a slot.
+truncateAtUpperBound ::
+  Eq (HeaderHash blk) =>
+  ChunkInfo ->
+  SlotNo ->
+  HeaderHash blk ->
+  [SizedEntry blk] ->
+  Either (IllegalStreamOperation blk) [SizedEntry blk]
+truncateAtUpperBound ci toSlot toHash = go [] Nothing
+ where
+  -- 'mbNear' = most recent same-slot non-match (see 'dropUntilLowerBound').
+  go _ mbNear [] = Left (StreamBoundNotFound (toSlot, toHash) mbNear)
+  go acc mbNear (e@(WithBlockSize _ entry) : rest) =
+    case compare (getEntrySlot ci entry) toSlot of
+      LT -> go (e : acc) mbNear rest
+      EQ
+        | headerHash entry == toHash -> Right (reverse (e : acc))
+        | otherwise -> go (e : acc) (Just entry) rest
+      GT -> Left (StreamBoundNotFound (toSlot, toHash) (Just entry))
 
 tipFromRemoteEnv ::
   forall blk.

--- a/src/GenesisSyncAccelerator/OnDemand.hs
+++ b/src/GenesisSyncAccelerator/OnDemand.hs
@@ -21,7 +21,9 @@ module GenesisSyncAccelerator.OnDemand
   , OnDemandRuntime (..)
   , OnDemandTip (..)
   , OnDemandState (..)
+  , SizedEntry
   , deleteChunkFiles
+  , dropUntilLowerBound
   , firstChunkNotAvailable
   , lastChunkNotAvailable
   , newOnDemandRuntime
@@ -29,6 +31,7 @@ module GenesisSyncAccelerator.OnDemand
   , onDemandIteratorFrom
   , readOnDemandTip
   , refreshTip
+  , truncateAtUpperBound
   ) where
 
 import Control.Concurrent.Async (Async, async, cancelMany, poll, waitCatch)

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -911,7 +911,7 @@ instance Arbitrary SlotNo where
   arbitrary = SlotNo <$> arbitrary
 
 instance Arbitrary TestHash where
-  arbitrary = testHashFromList . (: []) <$> arbitrary
+  arbitrary = makeTestHash <$> arbitrary
 
 instance Arbitrary Validity where
   arbitrary = (\p -> if p then Valid else Invalid) <$> arbitrary
@@ -1008,7 +1008,7 @@ genSlotForChunk :: ChunkInfo -> ChunkNo -> Gen SlotNo
 genSlotForChunk (UniformChunkSize ChunkSize{numRegularBlocks = s}) (ChunkNo n) = let lo = n * s in SlotNo <$> choose (lo, lo + s - 1)
 
 genUniqueHashes :: Int -> Gen [TestHash]
-genUniqueHashes n = map (\h -> testHashFromList [fromIntegral h]) <$> shuffle [1 .. n]
+genUniqueHashes n = map makeTestHash <$> shuffle [1 .. n]
 
 getMinChunk :: ChunkInfo -> [TestBlock] -> ChunkNo
 getMinChunk ci = minimum . map (blockChunk ci)
@@ -1038,6 +1038,10 @@ makeRuntimeWithNullRemoteAndNullLogging (TmpDir tmp) chunkInfo chunkedBlocks =
       , odcMaxCachedChunks = MaxCachedChunksCount . fromIntegral $ Map.size chunkedBlocks
       , odcPrefetchAhead = PrefetchChunksCount 0
       }
+
+-- The argument could be any Integral, but force Int for efficiency and to avoid type-defaults
+makeTestHash :: Int -> TestHash
+makeTestHash n = testHashFromList [fromIntegral n]
 
 modifyBlockHash :: TestBlock -> TestHash -> TestBlock
 modifyBlockHash b h = unsafeTestBlock (tbSlot b) h (tbValid b)
@@ -1126,9 +1130,9 @@ mkEntry boe hash =
       }
 
 ebbHash, mainHash, slot1Hash :: TestHash
-ebbHash = testHashFromList [1]
-mainHash = testHashFromList [2]
-slot1Hash = testHashFromList [3]
+ebbHash = makeTestHash 1
+mainHash = makeTestHash 2
+slot1Hash = makeTestHash 3
 
 -- EBB and main block both at slot 0, plus a main block at slot 1.
 sharedSlotEntries :: [SizedEntry TestBlock]
@@ -1152,7 +1156,7 @@ unit_dropUntilLowerBound_picksEBBAtSharedSlot =
 
 unit_dropUntilLowerBound_reportsNearMissOnExhaustion :: IO ()
 unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
-  let bogus = testHashFromList [99]
+  let bogus = makeTestHash 99
       onlySharedSlot = take 2 sharedSlotEntries
    in case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) bogus onlySharedSlot of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
@@ -1164,7 +1168,7 @@ unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
 
 unit_dropUntilLowerBound_reportsNearMissOnOvershoot :: IO ()
 unit_dropUntilLowerBound_reportsNearMissOnOvershoot =
-  let queryHash = testHashFromList [99]
+  let queryHash = makeTestHash 99
       querySlot = SlotNo 0
    in case dropUntilLowerBound sharedSlotChunkInfo querySlot queryHash sharedSlotEntries of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
@@ -1188,7 +1192,7 @@ unit_truncateAtUpperBound_picksMainBlockAtSharedSlot =
 
 unit_truncateAtUpperBound_reportsNearMissOnExhaustion :: IO ()
 unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
-  let bogus = testHashFromList [99]
+  let bogus = makeTestHash 99
       onlySharedSlot = take 2 sharedSlotEntries
    in case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) bogus onlySharedSlot of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
@@ -1200,7 +1204,7 @@ unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
 
 unit_truncateAtUpperBound_reportsNearMissOnOvershoot :: IO ()
 unit_truncateAtUpperBound_reportsNearMissOnOvershoot =
-  let queryHash = testHashFromList [99]
+  let queryHash = makeTestHash 99
       querySlot = SlotNo 0
    in case truncateAtUpperBound sharedSlotChunkInfo querySlot queryHash sharedSlotEntries of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -1301,6 +1301,6 @@ tests =
         "truncateAtUpperBound reports the same-slot near-miss on exhaustion"
         unit_truncateAtUpperBound_reportsNearMissOnExhaustion
     , testCase
-        "truncateAtUpperBound reports the previous-slot near-miss on overshoot"
+        "truncateAtUpperBound reports the next-slot near-miss on overshoot"
         unit_truncateAtUpperBound_reportsNearMissOnOvershoot
     ]

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -1285,7 +1285,7 @@ tests =
         "dropUntilLowerBound picks the EBB at a slot shared with a main block"
         unit_dropUntilLowerBound_picksEBBAtSharedSlot
     , testCase
-        "dropUntilLowerBound reports the same-slot near-miss on chunk exhaustion"
+        "dropUntilLowerBound reports the same-slot near-miss on exhaustion"
         unit_dropUntilLowerBound_reportsNearMissOnExhaustion
     , testCase
         "dropUntilLowerBound reports the next-slot near-miss on overshoot"
@@ -1297,7 +1297,7 @@ tests =
         "truncateAtUpperBound picks the main block at a slot shared with an EBB"
         unit_truncateAtUpperBound_picksMainBlockAtSharedSlot
     , testCase
-        "truncateAtUpperBound reports the same-slot near-miss on chunk exhaustion"
+        "truncateAtUpperBound reports the same-slot near-miss on exhaustion"
         unit_truncateAtUpperBound_reportsNearMissOnExhaustion
     , testCase
         "truncateAtUpperBound reports the previous-slot near-miss on overshoot"

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -1129,7 +1129,8 @@ mkEntry boe hash =
       , blockOrEBB = boe
       }
 
-ebbHash, mainHash, slot1Hash :: TestHash
+bogusQueryHash, ebbHash, mainHash, slot1Hash :: TestHash
+bogusQueryHash = makeTestHash 99
 ebbHash = makeTestHash 1
 mainHash = makeTestHash 2
 slot1Hash = makeTestHash 3
@@ -1156,24 +1157,22 @@ unit_dropUntilLowerBound_picksEBBAtSharedSlot =
 
 unit_dropUntilLowerBound_reportsNearMissOnExhaustion :: IO ()
 unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
-  let bogus = makeTestHash 99
-      onlySharedSlot = take 2 sharedSlotEntries
-   in case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) bogus onlySharedSlot of
+  let onlySharedSlot = take 2 sharedSlotEntries
+   in case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) bogusQueryHash onlySharedSlot of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= SlotNo 0
-          h @?= bogus
+          h @?= bogusQueryHash
           assertBool "near-miss must be a slot-0 entry" $
             headerHash near `elem` [ebbHash, mainHash]
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
 
 unit_dropUntilLowerBound_reportsNearMissOnOvershoot :: IO ()
 unit_dropUntilLowerBound_reportsNearMissOnOvershoot =
-  let queryHash = makeTestHash 99
-      querySlot = SlotNo 0
-   in case dropUntilLowerBound sharedSlotChunkInfo querySlot queryHash sharedSlotEntries of
+  let querySlot = SlotNo 0
+   in case dropUntilLowerBound sharedSlotChunkInfo querySlot bogusQueryHash sharedSlotEntries of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= querySlot
-          h @?= queryHash
+          h @?= bogusQueryHash
           headerHash near @?= slot1Hash
           getEntrySlot sharedSlotChunkInfo near @?= SlotNo 1
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
@@ -1192,24 +1191,22 @@ unit_truncateAtUpperBound_picksMainBlockAtSharedSlot =
 
 unit_truncateAtUpperBound_reportsNearMissOnExhaustion :: IO ()
 unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
-  let bogus = makeTestHash 99
-      onlySharedSlot = take 2 sharedSlotEntries
-   in case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) bogus onlySharedSlot of
+  let onlySharedSlot = take 2 sharedSlotEntries
+   in case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) bogusQueryHash onlySharedSlot of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= SlotNo 0
-          h @?= bogus
+          h @?= bogusQueryHash
           assertBool "near-miss must be a slot-0 entry" $
             headerHash near `elem` [ebbHash, mainHash]
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
 
 unit_truncateAtUpperBound_reportsNearMissOnOvershoot :: IO ()
 unit_truncateAtUpperBound_reportsNearMissOnOvershoot =
-  let queryHash = makeTestHash 99
-      querySlot = SlotNo 0
-   in case truncateAtUpperBound sharedSlotChunkInfo querySlot queryHash sharedSlotEntries of
+  let querySlot = SlotNo 0
+   in case truncateAtUpperBound sharedSlotChunkInfo querySlot bogusQueryHash sharedSlotEntries of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= querySlot
-          h @?= queryHash
+          h @?= bogusQueryHash
           headerHash near @?= slot1Hash
           getEntrySlot sharedSlotChunkInfo near @?= SlotNo 1
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -34,7 +34,7 @@ import GenesisSyncAccelerator.OnDemand
 import qualified GenesisSyncAccelerator.OnDemand as OnDemand
 import GenesisSyncAccelerator.RemoteStorage (FileType (..), RemoteStorageConfig (..), getFileName)
 import GenesisSyncAccelerator.Types (MaxCachedChunksCount (..), PrefetchChunksCount (..))
-import GenesisSyncAccelerator.Util (fpToHasFS)
+import GenesisSyncAccelerator.Util (fpToHasFS, getEntrySlot)
 import Ouroboros.Consensus.Block (StandardHash)
 import Ouroboros.Consensus.Block.Abstract
   ( ConvertRawHash
@@ -1162,6 +1162,18 @@ unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
             headerHash near `elem` [ebbHash, mainHash]
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
 
+unit_dropUntilLowerBound_reportsNearMissOnOvershoot :: IO ()
+unit_dropUntilLowerBound_reportsNearMissOnOvershoot =
+  let queryHash = testHashFromList [99]
+      querySlot = SlotNo 0
+   in case dropUntilLowerBound sharedSlotChunkInfo querySlot queryHash sharedSlotEntries of
+        Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
+          s @?= querySlot
+          h @?= queryHash
+          headerHash near @?= slot1Hash
+          getEntrySlot sharedSlotChunkInfo near @?= SlotNo 1
+        other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
+
 unit_truncateAtUpperBound_picksEBBAtSharedSlot :: IO ()
 unit_truncateAtUpperBound_picksEBBAtSharedSlot =
   case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) ebbHash sharedSlotEntries of
@@ -1184,6 +1196,18 @@ unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
           h @?= bogus
           assertBool "near-miss must be a slot-0 entry" $
             headerHash near `elem` [ebbHash, mainHash]
+        other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
+
+unit_truncateAtUpperBound_reportsNearMissOnOvershoot :: IO ()
+unit_truncateAtUpperBound_reportsNearMissOnOvershoot =
+  let queryHash = testHashFromList [99]
+      querySlot = SlotNo 0
+   in case truncateAtUpperBound sharedSlotChunkInfo querySlot queryHash sharedSlotEntries of
+        Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
+          s @?= querySlot
+          h @?= queryHash
+          headerHash near @?= slot1Hash
+          getEntrySlot sharedSlotChunkInfo near @?= SlotNo 1
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
 
 sizedEntry :: SizedEntry blk -> Entry blk
@@ -1261,6 +1285,9 @@ tests =
         "dropUntilLowerBound reports the same-slot near-miss on chunk exhaustion"
         unit_dropUntilLowerBound_reportsNearMissOnExhaustion
     , testCase
+        "dropUntilLowerBound reports the next-slot near-miss on overshoot"
+        unit_dropUntilLowerBound_reportsNearMissOnOvershoot
+    , testCase
         "truncateAtUpperBound picks the EBB at a slot shared with a main block"
         unit_truncateAtUpperBound_picksEBBAtSharedSlot
     , testCase
@@ -1269,4 +1296,7 @@ tests =
     , testCase
         "truncateAtUpperBound reports the same-slot near-miss on chunk exhaustion"
         unit_truncateAtUpperBound_reportsNearMissOnExhaustion
+    , testCase
+        "truncateAtUpperBound reports the previous-slot near-miss on overshoot"
+        unit_truncateAtUpperBound_reportsNearMissOnOvershoot
     ]

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -9,7 +9,7 @@
 
 module Test.GenesisSyncAccelerator.OnDemand.Iteration (tests) where
 
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import qualified Codec.CBOR.Write as CBOR
 import Codec.Serialise (Serialise (encode))
 import Control.Exception (try)
@@ -27,6 +27,9 @@ import GenesisSyncAccelerator.OnDemand
   , OnDemandConfig (..)
   , OnDemandRuntime (..)
   , OnDemandState (..)
+  , SizedEntry
+  , dropUntilLowerBound
+  , truncateAtUpperBound
   )
 import qualified GenesisSyncAccelerator.OnDemand as OnDemand
 import GenesisSyncAccelerator.RemoteStorage (FileType (..), RemoteStorageConfig (..), getFileName)
@@ -68,13 +71,13 @@ import Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary as Secondary
   ( writeAllEntries
   )
-import Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types (BlockOrEBB (..))
+import Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types (BlockOrEBB (..), WithBlockSize (..))
 import Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (fsPathChunkFile, fsPathPrimaryIndexFile)
 import Ouroboros.Consensus.Storage.Serialisation (HasBinaryBlockInfo (..))
 import Ouroboros.Consensus.Util.NormalForm.StrictTVar (readTVarIO, writeTVar)
 import System.FS.API (AllowExisting (MustBeNew), HasFS, OpenMode (..), withFile)
 import System.FS.API.Types (Handle)
-import System.FS.CRC (CRC, hPutAllCRC)
+import System.FS.CRC (CRC (..), hPutAllCRC)
 import System.FS.IO (HandleIO)
 import System.FilePath ((</>))
 import qualified System.IO.Temp as Temp
@@ -82,6 +85,7 @@ import Test.GenesisSyncAccelerator.Types (TmpDir (..))
 import Test.GenesisSyncAccelerator.Utilities (blockChunk, getLocalUrl, groupBlocksByChunk)
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
 import Test.Tasty.QuickCheck (testProperty)
 import Test.Util.TestBlock
   ( TestBlock
@@ -1102,6 +1106,90 @@ writeOneBlockOnly ::
 writeOneBlockOnly hasFS currentChunkHandle = hPutAllCRC hasFS currentChunkHandle . CBOR.toLazyByteString . encode
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Stream-bound regression tests (shared-slot EBB + first main block) ----------------------------------------------
+----------------------------------------------------------------------------------------------------------------------
+
+-- ChunkInfo where EBB epoch 0 maps to slot 0, sharing it with the first main block.
+sharedSlotChunkInfo :: ChunkInfo
+sharedSlotChunkInfo = UniformChunkSize $ ChunkSize True 10
+
+mkEntry :: BlockOrEBB -> TestHash -> SizedEntry TestBlock
+mkEntry boe hash =
+  WithBlockSize 0 $
+    Entry
+      { blockOffset = BlockOffset 0
+      , headerOffset = HeaderOffset 0
+      , headerSize = HeaderSize 0
+      , checksum = CRC 0
+      , headerHash = hash
+      , blockOrEBB = boe
+      }
+
+ebbHash, mainHash, slot1Hash :: TestHash
+ebbHash = testHashFromList [1]
+mainHash = testHashFromList [2]
+slot1Hash = testHashFromList [3]
+
+-- EBB and main block both at slot 0, plus a main block at slot 1.
+sharedSlotEntries :: [SizedEntry TestBlock]
+sharedSlotEntries =
+  [ mkEntry (EBB (EpochNo 0)) ebbHash
+  , mkEntry (Block (SlotNo 0)) mainHash
+  , mkEntry (Block (SlotNo 1)) slot1Hash
+  ]
+
+unit_dropUntilLowerBound_picksMainBlockAtSharedSlot :: IO ()
+unit_dropUntilLowerBound_picksMainBlockAtSharedSlot =
+  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) mainHash sharedSlotEntries of
+    Right (WithBlockSize _ e : _) -> headerHash e @?= mainHash
+    other -> fail $ "expected suffix starting at main block, got " ++ show other
+
+unit_dropUntilLowerBound_picksEBBAtSharedSlot :: IO ()
+unit_dropUntilLowerBound_picksEBBAtSharedSlot =
+  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) ebbHash sharedSlotEntries of
+    Right (WithBlockSize _ e : _) -> headerHash e @?= ebbHash
+    other -> fail $ "expected suffix starting at EBB, got " ++ show other
+
+unit_dropUntilLowerBound_reportsNearMissOnExhaustion :: IO ()
+unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
+  let bogus = testHashFromList [99]
+      onlySharedSlot = take 2 sharedSlotEntries
+   in case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) bogus onlySharedSlot of
+        Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
+          s @?= SlotNo 0
+          h @?= bogus
+          assertBool "near-miss must be a slot-0 entry" $
+            headerHash near `elem` [ebbHash, mainHash]
+        other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
+
+unit_truncateAtUpperBound_picksEBBAtSharedSlot :: IO ()
+unit_truncateAtUpperBound_picksEBBAtSharedSlot =
+  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) ebbHash sharedSlotEntries of
+    Right entries -> map (headerHash . sizedEntry) entries @?= [ebbHash]
+    other -> fail $ "expected prefix [EBB], got " ++ show other
+
+unit_truncateAtUpperBound_picksMainBlockAtSharedSlot :: IO ()
+unit_truncateAtUpperBound_picksMainBlockAtSharedSlot =
+  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) mainHash sharedSlotEntries of
+    Right entries -> map (headerHash . sizedEntry) entries @?= [ebbHash, mainHash]
+    other -> fail $ "expected prefix [EBB, main], got " ++ show other
+
+unit_truncateAtUpperBound_reportsNearMissOnExhaustion :: IO ()
+unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
+  let bogus = testHashFromList [99]
+      onlySharedSlot = take 2 sharedSlotEntries
+   in case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) bogus onlySharedSlot of
+        Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
+          s @?= SlotNo 0
+          h @?= bogus
+          assertBool "near-miss must be a slot-0 entry" $
+            headerHash near `elem` [ebbHash, mainHash]
+        other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
+
+sizedEntry :: SizedEntry blk -> Entry blk
+sizedEntry (WithBlockSize _ e) = e
+
+----------------------------------------------------------------------------------------------------------------------
 -- Property aggregation for export -----------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------------------------
 
@@ -1163,4 +1251,22 @@ tests =
     , testProperty
         "onDemandIteratorForRange errors correctly when lower bound exists and upper bound chunk exists but not the block itself"
         prop_onDemandIteratorForRangeErrorsCorrectlyWhenLowerBoundExistsAndUpperBoundChunkExistsButNotUpperBoundBlockItself
+    , testCase
+        "dropUntilLowerBound picks the main block at a slot shared with an EBB"
+        unit_dropUntilLowerBound_picksMainBlockAtSharedSlot
+    , testCase
+        "dropUntilLowerBound picks the EBB at a slot shared with a main block"
+        unit_dropUntilLowerBound_picksEBBAtSharedSlot
+    , testCase
+        "dropUntilLowerBound reports the same-slot near-miss on chunk exhaustion"
+        unit_dropUntilLowerBound_reportsNearMissOnExhaustion
+    , testCase
+        "truncateAtUpperBound picks the EBB at a slot shared with a main block"
+        unit_truncateAtUpperBound_picksEBBAtSharedSlot
+    , testCase
+        "truncateAtUpperBound picks the main block at a slot shared with an EBB"
+        unit_truncateAtUpperBound_picksMainBlockAtSharedSlot
+    , testCase
+        "truncateAtUpperBound reports the same-slot near-miss on chunk exhaustion"
+        unit_truncateAtUpperBound_reportsNearMissOnExhaustion
     ]

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -1162,6 +1162,7 @@ unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= SlotNo 0
           h @?= bogusQueryHash
+          getEntrySlot sharedSlotChunkInfo near @?= SlotNo 0
           assertBool "near-miss must be a slot-0 entry" $
             headerHash near `elem` [ebbHash, mainHash]
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
@@ -1196,6 +1197,7 @@ unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= SlotNo 0
           h @?= bogusQueryHash
+          getEntrySlot sharedSlotChunkInfo near @?= SlotNo 0
           assertBool "near-miss must be a slot-0 entry" $
             headerHash near `elem` [ebbHash, mainHash]
         other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other

--- a/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
+++ b/test/on-demand/Test/GenesisSyncAccelerator/OnDemand/Iteration.hs
@@ -1135,42 +1135,44 @@ ebbHash = makeTestHash 1
 mainHash = makeTestHash 2
 slot1Hash = makeTestHash 3
 
--- EBB and main block both at slot 0, plus a main block at slot 1.
-sharedSlotEntries :: [SizedEntry TestBlock]
-sharedSlotEntries =
+-- We're testing the case of an EBB and a main block in the same slot.
+sameSlotEntries :: [SizedEntry TestBlock]
+sameSlotEntries =
   [ mkEntry (EBB (EpochNo 0)) ebbHash
   , mkEntry (Block (SlotNo 0)) mainHash
-  , mkEntry (Block (SlotNo 1)) slot1Hash
   ]
+
+-- EBB and main block both at slot 0, plus a main block at slot 1.
+entriesIncludingSlotShare :: [SizedEntry TestBlock]
+entriesIncludingSlotShare = sameSlotEntries ++ [mkEntry (Block (SlotNo 1)) slot1Hash]
 
 unit_dropUntilLowerBound_picksMainBlockAtSharedSlot :: IO ()
 unit_dropUntilLowerBound_picksMainBlockAtSharedSlot =
-  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) mainHash sharedSlotEntries of
+  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) mainHash entriesIncludingSlotShare of
     Right (WithBlockSize _ e : _) -> headerHash e @?= mainHash
     other -> fail $ "expected suffix starting at main block, got " ++ show other
 
 unit_dropUntilLowerBound_picksEBBAtSharedSlot :: IO ()
 unit_dropUntilLowerBound_picksEBBAtSharedSlot =
-  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) ebbHash sharedSlotEntries of
+  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) ebbHash entriesIncludingSlotShare of
     Right (WithBlockSize _ e : _) -> headerHash e @?= ebbHash
     other -> fail $ "expected suffix starting at EBB, got " ++ show other
 
 unit_dropUntilLowerBound_reportsNearMissOnExhaustion :: IO ()
 unit_dropUntilLowerBound_reportsNearMissOnExhaustion =
-  let onlySharedSlot = take 2 sharedSlotEntries
-   in case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) bogusQueryHash onlySharedSlot of
-        Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
-          s @?= SlotNo 0
-          h @?= bogusQueryHash
-          getEntrySlot sharedSlotChunkInfo near @?= SlotNo 0
-          assertBool "near-miss must be a slot-0 entry" $
-            headerHash near `elem` [ebbHash, mainHash]
-        other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
+  case dropUntilLowerBound sharedSlotChunkInfo (SlotNo 0) bogusQueryHash sameSlotEntries of
+    Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
+      s @?= SlotNo 0
+      h @?= bogusQueryHash
+      getEntrySlot sharedSlotChunkInfo near @?= SlotNo 0
+      assertBool "near-miss must be a slot-0 entry" $
+        headerHash near `elem` [ebbHash, mainHash]
+    other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
 
 unit_dropUntilLowerBound_reportsNearMissOnOvershoot :: IO ()
 unit_dropUntilLowerBound_reportsNearMissOnOvershoot =
   let querySlot = SlotNo 0
-   in case dropUntilLowerBound sharedSlotChunkInfo querySlot bogusQueryHash sharedSlotEntries of
+   in case dropUntilLowerBound sharedSlotChunkInfo querySlot bogusQueryHash entriesIncludingSlotShare of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= querySlot
           h @?= bogusQueryHash
@@ -1180,32 +1182,31 @@ unit_dropUntilLowerBound_reportsNearMissOnOvershoot =
 
 unit_truncateAtUpperBound_picksEBBAtSharedSlot :: IO ()
 unit_truncateAtUpperBound_picksEBBAtSharedSlot =
-  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) ebbHash sharedSlotEntries of
+  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) ebbHash entriesIncludingSlotShare of
     Right entries -> map (headerHash . sizedEntry) entries @?= [ebbHash]
     other -> fail $ "expected prefix [EBB], got " ++ show other
 
 unit_truncateAtUpperBound_picksMainBlockAtSharedSlot :: IO ()
 unit_truncateAtUpperBound_picksMainBlockAtSharedSlot =
-  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) mainHash sharedSlotEntries of
+  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) mainHash entriesIncludingSlotShare of
     Right entries -> map (headerHash . sizedEntry) entries @?= [ebbHash, mainHash]
     other -> fail $ "expected prefix [EBB, main], got " ++ show other
 
 unit_truncateAtUpperBound_reportsNearMissOnExhaustion :: IO ()
 unit_truncateAtUpperBound_reportsNearMissOnExhaustion =
-  let onlySharedSlot = take 2 sharedSlotEntries
-   in case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) bogusQueryHash onlySharedSlot of
-        Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
-          s @?= SlotNo 0
-          h @?= bogusQueryHash
-          getEntrySlot sharedSlotChunkInfo near @?= SlotNo 0
-          assertBool "near-miss must be a slot-0 entry" $
-            headerHash near `elem` [ebbHash, mainHash]
-        other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
+  case truncateAtUpperBound sharedSlotChunkInfo (SlotNo 0) bogusQueryHash sameSlotEntries of
+    Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
+      s @?= SlotNo 0
+      h @?= bogusQueryHash
+      getEntrySlot sharedSlotChunkInfo near @?= SlotNo 0
+      assertBool "near-miss must be a slot-0 entry" $
+        headerHash near `elem` [ebbHash, mainHash]
+    other -> fail $ "expected StreamBoundNotFound with near-miss, got " ++ show other
 
 unit_truncateAtUpperBound_reportsNearMissOnOvershoot :: IO ()
 unit_truncateAtUpperBound_reportsNearMissOnOvershoot =
   let querySlot = SlotNo 0
-   in case truncateAtUpperBound sharedSlotChunkInfo querySlot bogusQueryHash sharedSlotEntries of
+   in case truncateAtUpperBound sharedSlotChunkInfo querySlot bogusQueryHash entriesIncludingSlotShare of
         Left (OnDemand.StreamBoundNotFound (s, h) (Just near)) -> do
           s @?= querySlot
           h @?= bogusQueryHash


### PR DESCRIPTION
This PR introduces two fixes surfaced during mainnet benchmarking:

1) Stream-bound entries should be picked by (slot, hash), not position.

`checkEntryMatch` first picked a candidate block by position **then** checked the hash. The problem is that blocks can share a slot in the very special case of Byron EBBs, where the first slot of each epoch contains a two blocks. This lead to `StreamBoundNotFound` errors when the block being picked was not the one requested.


2) Properly validate ChainSync intersection candidates against the on-disk chain.

When syncing from an empty chain, `cardano-node` actually sends two candidates:

a) A synthetic anchor computed from Origin and `genesis.json` file.
b) The Genesis origin point.

I am not exactly sure what the rationale is behind this, but we would previously accept the synthetic anchor without checking, which would later result in an error when the node tries to fetch that anchor.