### PR TITLE
feat: gsa-bench + sweep-matrix wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
               pkgs.hsPkgs.hsPkgs.ouroboros-consensus-cardano.components.exes.db-analyser
               pkgs.minio
               pkgs.minio-client
-              pkgs.python3
+              (pkgs.python3.withPackages (ps: [ ps.matplotlib ps.numpy ]))
               pkgs.curl
               pkgs.jq
               pkgs.iproute2

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,10 @@
               pkgs.hsPkgs.hsPkgs.ouroboros-consensus-cardano.components.exes.db-analyser
               pkgs.minio
               pkgs.minio-client
-              (pkgs.python3.withPackages (ps: [ ps.matplotlib ps.numpy ]))
+              (pkgs.python3.withPackages (ps: [
+                ps.matplotlib
+                ps.numpy
+              ]))
               pkgs.curl
               pkgs.jq
               pkgs.iproute2

--- a/genesis-sync-accelerator.cabal
+++ b/genesis-sync-accelerator.cabal
@@ -104,6 +104,36 @@ executable immdb-get-tip
     optparse-applicative,
     with-utf8,
 
+executable gsa-bench
+  import: common-all
+  hs-source-dirs: tools
+  main-is: gsa-bench.hs
+  ghc-options:
+    -threaded
+    -rtsopts
+    "-with-rtsopts=-N -I0 -A16m"
+
+  build-depends:
+    async,
+    bytestring,
+    cardano-crypto-class,
+    containers,
+    contra-tracer,
+    genesis-sync-accelerator,
+    network,
+    network-mux,
+    optparse-applicative,
+    ouroboros-consensus,
+    ouroboros-consensus-cardano,
+    ouroboros-consensus-diffusion,
+    ouroboros-network,
+    ouroboros-network-api,
+    ouroboros-network-framework,
+    ouroboros-network-protocols,
+    stm,
+    time,
+    with-utf8,
+
 library
   import: common-all
   hs-source-dirs: src

--- a/genesis-sync-accelerator.cabal
+++ b/genesis-sync-accelerator.cabal
@@ -132,6 +132,7 @@ executable gsa-bench
     ouroboros-network-protocols,
     stm,
     time,
+    typed-protocols,
     with-utf8,
 
 library

--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -1,0 +1,60 @@
+# gsa-bench throughput sweep
+
+Synthetic node-to-node throughput benchmark for GSA. `gsa-bench` opens N
+parallel ChainSync+BlockFetch initiator connections against a running
+GSA, pulls blocks as fast as possible, and reports throughput.
+`sweep-matrix.sh` drives a (`batch_size` × `parallel-clients`) grid;
+`plot.py` renders the resulting CSV.
+
+## Prerequisites
+
+- `nix develop .#integration-test` shell (provides `python3` with
+  matplotlib + numpy).
+- A running GSA listening on `GSA_PORT` against the data source you want
+  to benchmark, e.g.:
+
+  ```bash
+  genesis-sync-accelerator \
+    --node-config $HOME/gsa-snapshot/config/config.json \
+    --rs-src-url http://127.0.0.1:9100/chunks/immutable \
+    --cache-dir $HOME/gsa-snapshot/local-run/gsa-cache \
+    --port 8781
+  ```
+
+## Running
+
+```bash
+nix develop .#integration-test
+cabal build exe:gsa-bench
+
+GSA_PORT=8781 \
+NODE_CONFIG=~/gsa-snapshot/config/config.json \
+OUT=./sweep-matrix.csv \
+bash test/bench/sweep-matrix.sh
+
+python3 test/bench/plot.py sweep-matrix.csv .
+```
+
+Output: `sweep-matrix.csv` plus four PNGs (throughput vs batch in MB/s and
+blocks/s, a parallel × batch heatmap, and scaling vs parallel clients).
+
+## Environment variables
+
+### `sweep-matrix.sh`
+
+| Var | Default | Description |
+|---|---|---|
+| `BENCH` | autodetected in `dist-newstyle/` | Path to `gsa-bench` |
+| `GSA_HOST` | `127.0.0.1` | GSA host |
+| `GSA_PORT` | `8781` | GSA port |
+| `NODE_CONFIG` | `$HOME/gsa-snapshot/config/config.json` | Cardano `config.json` |
+| `OUT` | `./sweep-matrix.csv` | Output CSV |
+| `DUR` | `15` | Per-cell duration (s) |
+| `BATCHES` | `50 100 250 500 1000 2000 5000` | Batch sizes to sweep |
+| `PARALLELS` | `1 2 4 8 16` | Parallel-client counts to sweep |
+
+## Troubleshooting
+
+- **Sweep stops early or shows `FAILED`.** Verify GSA is up
+  (`ss -ltn | grep 8781`) and that `gsa-bench` was rebuilt against the
+  current source (`cabal build exe:gsa-bench`).

--- a/test/bench/plot.py
+++ b/test/bench/plot.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Plot GSA throughput matrix from sweep-matrix.csv.
+
+Emits four PNGs into the output directory:
+  throughput-mbps.png           — MB/s vs batch size, one line per parallel
+  throughput-blocks.png         — blocks/s vs batch size, one line per parallel
+  throughput-heatmap-mbps.png   — MB/s heatmap (parallel × batch)
+  throughput-scaling.png        — MB/s vs parallel clients, one line per batch
+
+Usage:
+  python3 plot.py [csv-path] [out-dir]
+
+Defaults to sweep-matrix.csv in CWD and writes plots into CWD.
+"""
+import csv
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+CSV = Path(sys.argv[1] if len(sys.argv) > 1 else "sweep-matrix.csv")
+OUT = Path(sys.argv[2] if len(sys.argv) > 2 else ".")
+OUT.mkdir(parents=True, exist_ok=True)
+
+rows = []
+with CSV.open() as f:
+    for r in csv.DictReader(f):
+        if not r.get("blocks_per_sec"):
+            continue
+        rows.append(
+            {
+                "batch": int(r["batch"]),
+                "parallel": int(r["parallel"]),
+                "bps": float(r["blocks_per_sec"]),
+                "mbps": float(r["mb_per_sec"]),
+                "bpb": float(r["bytes_per_block"]) if r.get("bytes_per_block") else 0.0,
+            }
+        )
+
+batches = sorted({r["batch"] for r in rows})
+parallels = sorted({r["parallel"] for r in rows})
+print(f"batches={batches}  parallels={parallels}  rows={len(rows)}")
+
+
+def grid(key):
+    m = np.zeros((len(parallels), len(batches)))
+    for r in rows:
+        i = parallels.index(r["parallel"])
+        j = batches.index(r["batch"])
+        m[i, j] = r[key]
+    return m
+
+
+mbps = grid("mbps")
+bps = grid("bps")
+
+# MB/s vs batch, one line per parallel
+plt.figure(figsize=(10, 6))
+for i, p in enumerate(parallels):
+    plt.plot(batches, mbps[i], marker="o", label=f"parallel={p}")
+plt.xscale("log")
+plt.xticks(batches, [str(b) for b in batches])
+plt.xlabel("Batch size (points per MsgRequestRange)")
+plt.ylabel("MB / s")
+plt.title("GSA throughput (MB/s) — Byron blocks, warm cache")
+plt.grid(True, alpha=0.4)
+plt.legend()
+plt.tight_layout()
+plt.savefig(OUT / "throughput-mbps.png", dpi=120)
+plt.close()
+
+# blocks/s vs batch
+plt.figure(figsize=(10, 6))
+for i, p in enumerate(parallels):
+    plt.plot(batches, bps[i], marker="o", label=f"parallel={p}")
+plt.xscale("log")
+plt.xticks(batches, [str(b) for b in batches])
+plt.xlabel("Batch size")
+plt.ylabel("blocks / s")
+plt.title("GSA throughput (blocks/s)")
+plt.grid(True, alpha=0.4)
+plt.legend()
+plt.tight_layout()
+plt.savefig(OUT / "throughput-blocks.png", dpi=120)
+plt.close()
+
+# MB/s heatmap
+fig, ax = plt.subplots(figsize=(9, 5))
+im = ax.imshow(mbps, aspect="auto", cmap="viridis")
+ax.set_xticks(range(len(batches)), [str(b) for b in batches])
+ax.set_yticks(range(len(parallels)), [str(p) for p in parallels])
+ax.set_xlabel("Batch size")
+ax.set_ylabel("Parallel clients")
+ax.set_title("GSA throughput heatmap (MB/s)")
+peak = mbps.max() if mbps.size else 1.0
+for i in range(mbps.shape[0]):
+    for j in range(mbps.shape[1]):
+        ax.text(
+            j,
+            i,
+            f"{mbps[i, j]:.1f}",
+            ha="center",
+            va="center",
+            color="white" if mbps[i, j] < peak * 0.55 else "black",
+            fontsize=9,
+        )
+plt.colorbar(im, label="MB/s")
+plt.tight_layout()
+plt.savefig(OUT / "throughput-heatmap-mbps.png", dpi=120)
+plt.close()
+
+# MB/s vs parallel, one line per batch
+plt.figure(figsize=(10, 6))
+for j, b in enumerate(batches):
+    plt.plot(parallels, mbps[:, j], marker="s", label=f"batch={b}")
+plt.xlabel("Parallel clients")
+plt.ylabel("MB / s")
+plt.title("GSA throughput scaling with clients")
+plt.grid(True, alpha=0.4)
+plt.legend()
+plt.tight_layout()
+plt.savefig(OUT / "throughput-scaling.png", dpi=120)
+plt.close()
+
+print(f"plots → {OUT}/throughput-*.png")

--- a/test/bench/plot.py
+++ b/test/bench/plot.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
-"""Plot GSA throughput matrix from sweep-matrix.csv.
+"""Plot GSA throughput matrix.
 
-Emits four PNGs into the output directory:
-  throughput-mbps.png           — MB/s vs batch size, one line per parallel
-  throughput-blocks.png         — blocks/s vs batch size, one line per parallel
-  throughput-heatmap-mbps.png   — MB/s heatmap (parallel × batch)
-  throughput-scaling.png        — MB/s vs parallel clients, one line per batch
+Auto-detects the sweep schema from the CSV header:
+
+* `batch,parallel,…` (sweep-matrix.csv) — multi-connection model. Emits:
+    throughput-mbps.png           MB/s vs batch, one line per parallel
+    throughput-blocks.png         blocks/s vs batch, one line per parallel
+    throughput-heatmap-mbps.png   parallel × batch heatmap
+    throughput-scaling.png        MB/s vs parallel, one line per batch
+
+* `batch,max_in_flight,…` (sweep-pipeline.csv) — single-connection
+  pipelined model (cardano-node-shaped). Emits:
+    throughput-pipeline-mbps.png         MB/s vs batch, one line per K
+    throughput-pipeline-blocks.png       blocks/s vs batch, one line per K
+    throughput-pipeline-heatmap-mbps.png K × batch heatmap
 
 Usage:
   python3 plot.py [csv-path] [out-dir]
@@ -26,15 +34,36 @@ CSV = Path(sys.argv[1] if len(sys.argv) > 1 else "sweep-matrix.csv")
 OUT = Path(sys.argv[2] if len(sys.argv) > 2 else ".")
 OUT.mkdir(parents=True, exist_ok=True)
 
-rows = []
 with CSV.open() as f:
-    for r in csv.DictReader(f):
+    reader = csv.DictReader(f)
+    fieldnames = reader.fieldnames or []
+    if "max_in_flight" in fieldnames:
+        SCHEMA = "pipeline"
+        Y_KEY = "max_in_flight"
+        Y_LABEL = "Max in-flight (K)"
+        Y_LEGEND = "K"
+        OUT_PREFIX = "throughput-pipeline"
+        TITLE_SUFFIX = "single connection, pipelined, Byron warm"
+    elif "parallel" in fieldnames:
+        SCHEMA = "parallel"
+        Y_KEY = "parallel"
+        Y_LABEL = "Parallel clients"
+        Y_LEGEND = "parallel"
+        OUT_PREFIX = "throughput"
+        TITLE_SUFFIX = "Byron blocks, warm cache"
+    else:
+        raise SystemExit(
+            f"unrecognised CSV schema in {CSV}: expected `parallel` or `max_in_flight` column"
+        )
+
+    rows = []
+    for r in reader:
         if not r.get("blocks_per_sec"):
             continue
         rows.append(
             {
                 "batch": int(r["batch"]),
-                "parallel": int(r["parallel"]),
+                "y": int(r[Y_KEY]),
                 "bps": float(r["blocks_per_sec"]),
                 "mbps": float(r["mb_per_sec"]),
                 "bpb": float(r["bytes_per_block"]) if r.get("bytes_per_block") else 0.0,
@@ -42,14 +71,14 @@ with CSV.open() as f:
         )
 
 batches = sorted({r["batch"] for r in rows})
-parallels = sorted({r["parallel"] for r in rows})
-print(f"batches={batches}  parallels={parallels}  rows={len(rows)}")
+ys = sorted({r["y"] for r in rows})
+print(f"schema={SCHEMA}  batches={batches}  {Y_KEY}s={ys}  rows={len(rows)}")
 
 
 def grid(key):
-    m = np.zeros((len(parallels), len(batches)))
+    m = np.zeros((len(ys), len(batches)))
     for r in rows:
-        i = parallels.index(r["parallel"])
+        i = ys.index(r["y"])
         j = batches.index(r["batch"])
         m[i, j] = r[key]
     return m
@@ -58,44 +87,44 @@ def grid(key):
 mbps = grid("mbps")
 bps = grid("bps")
 
-# MB/s vs batch, one line per parallel
+# MB/s vs batch, one line per Y
 plt.figure(figsize=(10, 6))
-for i, p in enumerate(parallels):
-    plt.plot(batches, mbps[i], marker="o", label=f"parallel={p}")
+for i, y in enumerate(ys):
+    plt.plot(batches, mbps[i], marker="o", label=f"{Y_LEGEND}={y}")
 plt.xscale("log")
 plt.xticks(batches, [str(b) for b in batches])
 plt.xlabel("Batch size (points per MsgRequestRange)")
 plt.ylabel("MB / s")
-plt.title("GSA throughput (MB/s) — Byron blocks, warm cache")
+plt.title(f"GSA throughput (MB/s) — {TITLE_SUFFIX}")
 plt.grid(True, alpha=0.4)
 plt.legend()
 plt.tight_layout()
-plt.savefig(OUT / "throughput-mbps.png", dpi=120)
+plt.savefig(OUT / f"{OUT_PREFIX}-mbps.png", dpi=120)
 plt.close()
 
 # blocks/s vs batch
 plt.figure(figsize=(10, 6))
-for i, p in enumerate(parallels):
-    plt.plot(batches, bps[i], marker="o", label=f"parallel={p}")
+for i, y in enumerate(ys):
+    plt.plot(batches, bps[i], marker="o", label=f"{Y_LEGEND}={y}")
 plt.xscale("log")
 plt.xticks(batches, [str(b) for b in batches])
 plt.xlabel("Batch size")
 plt.ylabel("blocks / s")
-plt.title("GSA throughput (blocks/s)")
+plt.title(f"GSA throughput (blocks/s) — {TITLE_SUFFIX}")
 plt.grid(True, alpha=0.4)
 plt.legend()
 plt.tight_layout()
-plt.savefig(OUT / "throughput-blocks.png", dpi=120)
+plt.savefig(OUT / f"{OUT_PREFIX}-blocks.png", dpi=120)
 plt.close()
 
 # MB/s heatmap
 fig, ax = plt.subplots(figsize=(9, 5))
 im = ax.imshow(mbps, aspect="auto", cmap="viridis")
 ax.set_xticks(range(len(batches)), [str(b) for b in batches])
-ax.set_yticks(range(len(parallels)), [str(p) for p in parallels])
+ax.set_yticks(range(len(ys)), [str(y) for y in ys])
 ax.set_xlabel("Batch size")
-ax.set_ylabel("Parallel clients")
-ax.set_title("GSA throughput heatmap (MB/s)")
+ax.set_ylabel(Y_LABEL)
+ax.set_title(f"GSA throughput heatmap (MB/s) — {TITLE_SUFFIX}")
 peak = mbps.max() if mbps.size else 1.0
 for i in range(mbps.shape[0]):
     for j in range(mbps.shape[1]):
@@ -110,20 +139,21 @@ for i in range(mbps.shape[0]):
         )
 plt.colorbar(im, label="MB/s")
 plt.tight_layout()
-plt.savefig(OUT / "throughput-heatmap-mbps.png", dpi=120)
+plt.savefig(OUT / f"{OUT_PREFIX}-heatmap-mbps.png", dpi=120)
 plt.close()
 
-# MB/s vs parallel, one line per batch
-plt.figure(figsize=(10, 6))
-for j, b in enumerate(batches):
-    plt.plot(parallels, mbps[:, j], marker="s", label=f"batch={b}")
-plt.xlabel("Parallel clients")
-plt.ylabel("MB / s")
-plt.title("GSA throughput scaling with clients")
-plt.grid(True, alpha=0.4)
-plt.legend()
-plt.tight_layout()
-plt.savefig(OUT / "throughput-scaling.png", dpi=120)
-plt.close()
+if SCHEMA == "parallel":
+    # MB/s vs parallel, one line per batch — only meaningful for the parallel sweep
+    plt.figure(figsize=(10, 6))
+    for j, b in enumerate(batches):
+        plt.plot(ys, mbps[:, j], marker="s", label=f"batch={b}")
+    plt.xlabel(Y_LABEL)
+    plt.ylabel("MB / s")
+    plt.title("GSA throughput scaling with clients")
+    plt.grid(True, alpha=0.4)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(OUT / "throughput-scaling.png", dpi=120)
+    plt.close()
 
-print(f"plots → {OUT}/throughput-*.png")
+print(f"plots → {OUT}/{OUT_PREFIX}-*.png")

--- a/test/bench/sweep-matrix.sh
+++ b/test/bench/sweep-matrix.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# GSA throughput sweep: batch_size × parallel-clients matrix, warm cache.
+#
+# Drives `gsa-bench` against an already-running GSA (which must already be
+# serving from a populated chunk cache; the easiest way to set that up is
+# `bash test/bench/run-local.sh STOP_AFTER_CHUNKS=10` — once it
+# finishes, GSA's --cache-dir holds a real working set).
+#
+# Emits sweep-matrix.csv with one row per (BATCH, P) cell:
+#   batch,parallel,duration_s,blocks,bytes,blocks_per_sec,mb_per_sec,bytes_per_block
+#
+# Usage:
+#   nix develop .#integration-test
+#   GSA_PORT=8781 NODE_CONFIG=~/gsa-snapshot/config/config.json \
+#     bash test/bench/sweep-matrix.sh
+#
+# Env (sensible defaults; override as needed):
+#   BENCH            Path to gsa-bench (default: cabal-built one in dist-newstyle)
+#   GSA_HOST         GSA host (default: 127.0.0.1)
+#   GSA_PORT         GSA port (default: 8781)
+#   NODE_CONFIG      Cardano network config.json (default: $HOME/gsa-snapshot/config/config.json)
+#   OUT              Output CSV path (default: ./sweep-matrix.csv)
+#   DUR              Per-cell duration in seconds (default: 15)
+#   BATCHES          Space-separated batch sizes (default: "50 100 250 500 1000 2000 5000")
+#   PARALLELS        Space-separated parallel-client counts (default: "1 2 4 8 16")
+#   WARMUP_PARALLEL  Warm-up parallel count (default: 4)
+#   WARMUP_BATCH     Warm-up batch size (default: 500)
+#   WARMUP_DURATION  Warm-up duration in seconds (default: 10)
+
+set -u
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null \
+              || echo "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)")"
+
+BENCH="${BENCH:-$(find "$REPO_ROOT/dist-newstyle" -name gsa-bench -type f -executable 2>/dev/null | head -1)}"
+GSA_HOST="${GSA_HOST:-127.0.0.1}"
+GSA_PORT="${GSA_PORT:-8781}"
+NODE_CONFIG="${NODE_CONFIG:-$HOME/gsa-snapshot/config/config.json}"
+OUT="${OUT:-./sweep-matrix.csv}"
+DUR="${DUR:-15}"
+BATCHES="${BATCHES:-50 100 250 500 1000 2000 5000}"
+PARALLELS="${PARALLELS:-1 2 4 8 16}"
+WARMUP_PARALLEL="${WARMUP_PARALLEL:-4}"
+WARMUP_BATCH="${WARMUP_BATCH:-500}"
+WARMUP_DURATION="${WARMUP_DURATION:-10}"
+
+if [[ -z "$BENCH" || ! -x "$BENCH" ]]; then
+  echo "error: gsa-bench not found. Build first: cabal build exe:gsa-bench" >&2
+  exit 1
+fi
+if [[ ! -f "$NODE_CONFIG" ]]; then
+  echo "error: NODE_CONFIG not found at $NODE_CONFIG" >&2
+  exit 1
+fi
+if ! ss -ltn 2>/dev/null | grep -q ":$GSA_PORT\b"; then
+  echo "error: nothing listening on $GSA_HOST:$GSA_PORT — start GSA first" >&2
+  exit 1
+fi
+
+# Warm the GSA's chunk cache so cold-start I/O doesn't pollute the first cell.
+echo "warmup: parallel=$WARMUP_PARALLEL batch=$WARMUP_BATCH duration=${WARMUP_DURATION}s"
+"$BENCH" --host "$GSA_HOST" --port "$GSA_PORT" --node-config "$NODE_CONFIG" \
+  --duration "$WARMUP_DURATION" --parallel "$WARMUP_PARALLEL" \
+  --batch-size "$WARMUP_BATCH" --report-interval 30 >/dev/null 2>&1
+echo "warmup done"
+
+echo "batch,parallel,duration_s,blocks,bytes,blocks_per_sec,mb_per_sec,bytes_per_block" > "$OUT"
+
+for BATCH in $BATCHES; do
+  for P in $PARALLELS; do
+    RESULT=$(timeout $((DUR + 10)) "$BENCH" \
+      --host "$GSA_HOST" --port "$GSA_PORT" --node-config "$NODE_CONFIG" \
+      --duration "$DUR" --parallel "$P" --batch-size "$BATCH" \
+      --report-interval 30 2>&1 | grep '^{' | head -1)
+    if [[ -n "$RESULT" ]]; then
+      DUR_S=$(  echo "$RESULT" | sed -n 's/.*"duration_s":\([0-9.]*\).*/\1/p')
+      BLOCKS=$( echo "$RESULT" | sed -n 's/.*"blocks":\([0-9]*\).*/\1/p')
+      BYTES=$(  echo "$RESULT" | sed -n 's/.*"bytes":\([0-9]*\).*/\1/p')
+      BPS=$(    echo "$RESULT" | sed -n 's/.*"blocks_per_sec":\([0-9.]*\).*/\1/p')
+      MBPS=$(   echo "$RESULT" | sed -n 's/.*"mb_per_sec":\([0-9.]*\).*/\1/p')
+      BPB=$(python3 -c "print(f'{$BYTES/$BLOCKS:.2f}')" 2>/dev/null || echo 0)
+      printf "%d,%d,%s,%s,%s,%s,%s,%s\n" \
+        "$BATCH" "$P" "$DUR_S" "$BLOCKS" "$BYTES" "$BPS" "$MBPS" "$BPB" \
+        | tee -a "$OUT"
+    else
+      echo "$BATCH,$P,FAILED" | tee -a "$OUT"
+    fi
+    sleep 1
+  done
+done
+
+echo "done → $OUT ($(wc -l < "$OUT") lines incl. header)"

--- a/test/bench/sweep-pipeline.sh
+++ b/test/bench/sweep-pipeline.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# GSA throughput sweep: max-in-flight × batch_size matrix on a single
+# connection. This is the cardano-node-shaped concurrency model — pipelined
+# requests on one TCP connection, not multiple TCP connections.
+#
+# Drives `gsa-bench` against an already-running GSA (which must already be
+# serving from a populated chunk cache; see `test/bench/run-local.sh`).
+#
+# Emits sweep-pipeline.csv with one row per (BATCH, K) cell:
+#   batch,max_in_flight,duration_s,blocks,bytes,blocks_per_sec,mb_per_sec,bytes_per_block
+#
+# Usage:
+#   nix develop .#integration-test
+#   GSA_PORT=8781 NODE_CONFIG=~/gsa-snapshot/config/config.json \
+#     bash test/bench/sweep-pipeline.sh
+#
+# Env (sensible defaults; override as needed):
+#   BENCH            Path to gsa-bench (default: cabal-built one in dist-newstyle)
+#   GSA_HOST         GSA host (default: 127.0.0.1)
+#   GSA_PORT         GSA port (default: 8781)
+#   NODE_CONFIG      Cardano network config.json (default: $HOME/gsa-snapshot/config/config.json)
+#   OUT              Output CSV path (default: ./sweep-pipeline.csv)
+#   DUR              Per-cell duration in seconds (default: 15)
+#   BATCHES          Space-separated batch sizes (default: "4 16 64 256 1024")
+#   MAX_IN_FLIGHTS   Space-separated pipeline depths (default: "1 4 16 64 100")
+#   WARMUP_BATCH     Warm-up batch size (default: 256)
+#   WARMUP_K         Warm-up max-in-flight (default: 16)
+#   WARMUP_DURATION  Warm-up duration in seconds (default: 10)
+
+set -u
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null \
+              || echo "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)")"
+
+BENCH="${BENCH:-$(find "$REPO_ROOT/dist-newstyle" -name gsa-bench -type f -executable 2>/dev/null | head -1)}"
+GSA_HOST="${GSA_HOST:-127.0.0.1}"
+GSA_PORT="${GSA_PORT:-8781}"
+NODE_CONFIG="${NODE_CONFIG:-$HOME/gsa-snapshot/config/config.json}"
+OUT="${OUT:-./sweep-pipeline.csv}"
+DUR="${DUR:-15}"
+BATCHES="${BATCHES:-4 16 64 256 1024}"
+MAX_IN_FLIGHTS="${MAX_IN_FLIGHTS:-1 4 16 64 100}"
+WARMUP_BATCH="${WARMUP_BATCH:-256}"
+WARMUP_K="${WARMUP_K:-16}"
+WARMUP_DURATION="${WARMUP_DURATION:-10}"
+
+if [[ -z "$BENCH" || ! -x "$BENCH" ]]; then
+  echo "error: gsa-bench not found. Build first: cabal build exe:gsa-bench" >&2
+  exit 1
+fi
+if [[ ! -f "$NODE_CONFIG" ]]; then
+  echo "error: NODE_CONFIG not found at $NODE_CONFIG" >&2
+  exit 1
+fi
+if ! ss -ltn 2>/dev/null | grep -q ":$GSA_PORT\b"; then
+  echo "error: nothing listening on $GSA_HOST:$GSA_PORT — start GSA first" >&2
+  exit 1
+fi
+
+# Warm the GSA's chunk cache so cold-start I/O doesn't pollute the first cell.
+echo "warmup: parallel=1 max-in-flight=$WARMUP_K batch=$WARMUP_BATCH duration=${WARMUP_DURATION}s"
+"$BENCH" --host "$GSA_HOST" --port "$GSA_PORT" --node-config "$NODE_CONFIG" \
+  --duration "$WARMUP_DURATION" --parallel 1 \
+  --max-in-flight "$WARMUP_K" --batch-size "$WARMUP_BATCH" \
+  --report-interval 30 >/dev/null 2>&1
+echo "warmup done"
+
+echo "batch,max_in_flight,duration_s,blocks,bytes,blocks_per_sec,mb_per_sec,bytes_per_block" > "$OUT"
+
+for BATCH in $BATCHES; do
+  for K in $MAX_IN_FLIGHTS; do
+    RESULT=$(timeout $((DUR + 10)) "$BENCH" \
+      --host "$GSA_HOST" --port "$GSA_PORT" --node-config "$NODE_CONFIG" \
+      --duration "$DUR" --parallel 1 --max-in-flight "$K" --batch-size "$BATCH" \
+      --report-interval 30 2>&1 | grep '^{' | head -1)
+    if [[ -n "$RESULT" ]]; then
+      DUR_S=$(  echo "$RESULT" | sed -n 's/.*"duration_s":\([0-9.]*\).*/\1/p')
+      BLOCKS=$( echo "$RESULT" | sed -n 's/.*"blocks":\([0-9]*\).*/\1/p')
+      BYTES=$(  echo "$RESULT" | sed -n 's/.*"bytes":\([0-9]*\).*/\1/p')
+      BPS=$(    echo "$RESULT" | sed -n 's/.*"blocks_per_sec":\([0-9.]*\).*/\1/p')
+      MBPS=$(   echo "$RESULT" | sed -n 's/.*"mb_per_sec":\([0-9.]*\).*/\1/p')
+      BPB=$(python3 -c "print(f'{$BYTES/$BLOCKS:.2f}')" 2>/dev/null || echo 0)
+      printf "%d,%d,%s,%s,%s,%s,%s,%s\n" \
+        "$BATCH" "$K" "$DUR_S" "$BLOCKS" "$BYTES" "$BPS" "$MBPS" "$BPB" \
+        | tee -a "$OUT"
+    else
+      echo "$BATCH,$K,FAILED" | tee -a "$OUT"
+    fi
+    sleep 1
+  done
+done
+
+echo "done → $OUT ($(wc -l < "$OUT") lines incl. header)"

--- a/tools/gsa-bench.hs
+++ b/tools/gsa-bench.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -76,7 +77,7 @@ import Ouroboros.Network.Block
   , Tip (..)
   , getTipPoint
   )
-import Ouroboros.Network.Driver.Simple (runPeer)
+import Ouroboros.Network.Driver.Simple (runPeer, runPipelinedPeer)
 import qualified Ouroboros.Network.IOManager as IOManager
 import Ouroboros.Network.Magic (NetworkMagic)
 import Ouroboros.Network.Mux
@@ -94,14 +95,13 @@ import Ouroboros.Network.PeerSelection.PeerSharing.Codec
   ( decodeRemoteAddress
   , encodeRemoteAddress
   )
-import Ouroboros.Network.Protocol.BlockFetch.Client
-  ( BlockFetchClient (..)
-  , BlockFetchReceiver (..)
-  , BlockFetchRequest (..)
-  , BlockFetchResponse (..)
-  , blockFetchClientPeer
+import Ouroboros.Network.Protocol.BlockFetch.Type
+  ( BlockFetch (..)
+  , ChainRange (..)
+  , Message (..)
   )
-import Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
+import Network.TypedProtocol.Core
+import Network.TypedProtocol.Peer.Client
 import Ouroboros.Network.Protocol.ChainSync.Client
   ( ChainSyncClient (..)
   , ClientStIdle (..)
@@ -126,6 +126,7 @@ data Opts = Opts
   , oPort :: PortNumber
   , oNodeConfig :: FilePath
   , oParallel :: Int
+  , oMaxInFlight :: Int
   , oMaxBlocks :: Maybe Word64
   , oDuration :: Maybe Double
   , oReportInterval :: Double
@@ -162,9 +163,16 @@ optsParser =
     oParallel <-
       option auto $
         long "parallel"
-          <> help "Number of concurrent fake-node connections (default 1)"
+          <> help "Number of concurrent fake-node connections (default 1). Each connection opens a separate TCP stream — models the multi-peer case, not single-peer pipelining (use --max-in-flight for that)."
           <> metavar "N"
           <> value 1
+          <> showDefault
+    oMaxInFlight <-
+      option auto $
+        long "max-in-flight"
+          <> help "Maximum outstanding BlockFetch MsgRequestRange per connection (default 10, cap 100). This is the cardano-node-shaped concurrency knob: multiple ranges pipelined on a single TCP connection. Set to 1 for non-pipelined behaviour."
+          <> metavar "K"
+          <> value 10
           <> showDefault
     oMaxBlocks <-
       optional $
@@ -247,10 +255,12 @@ data ClientState = ClientState
   -- signal to drain any final partial batch and then send 'MsgClientDone'.
   }
 
-newClientState :: ClientCounter -> TVar Bool -> Int -> IO ClientState
-newClientState counter stop batchSize = do
+newClientState :: ClientCounter -> TVar Bool -> Int -> Int -> IO ClientState
+newClientState counter stop batchSize maxInFlight = do
   tip <- newTVarIO GenesisPoint
-  let cap = fromIntegral (max 2048 (4 * batchSize))
+  -- Capacity must hold at least K outstanding batches + a few for headroom,
+  -- otherwise ChainSync can't keep BlockFetch's pipeline full.
+  let cap = fromIntegral (max 2048 ((maxInFlight + 4) * batchSize))
   q <- newTBQueueIO cap
   reachedTip <- newTVarIO False
   pure
@@ -322,46 +332,129 @@ chainSyncBenchClient st =
       -- that case doesn't occur when benching against an ImmutableDB.
       }
 
--- ----- BlockFetch client: batched range requests -----------------------------
+-- ----- BlockFetch client: pipelined batched range requests -----------------
 --
--- Drain up to @batchSize@ 'Point's from 'csHeaderQ', form a
--- @ChainRange (firstPoint, lastPoint)@ covering them, and issue a single
--- 'MsgRequestRange'. The server responds with 'MsgStartBatch' followed by one
--- 'MsgBlock' per point then 'MsgBatchDone'. We count bytes per received block.
--- One round-trip per batch amortises RTT overhead across @batchSize@ blocks.
+-- Mirror cardano-node's BlockFetch.Client behaviour: keep up to @K@
+-- 'MsgRequestRange' requests outstanding on a single connection, pipelining
+-- new requests before the previous batch's 'MsgBatchDone' lands. Each request
+-- carries a @ChainRange@ covering up to @batchSize@ Points drained from
+-- 'csHeaderQ'. Bytes are counted per received 'MsgBlock'.
+--
+-- This uses the lower-level typed-protocols 'Client' API (rather than the
+-- higher-level 'BlockFetchSender' API) because step-by-step decisions need
+-- to query the STM-backed header queue and stop flag — which 'BlockFetchSender'
+-- can't express but 'Client'+'Effect' can.
 
-blockFetchBenchClient :: Int -> ClientState -> BlockFetchClient (Serialised Blk) (Point Blk) IO ()
-blockFetchBenchClient batchSize st = BlockFetchClient nextRequest
+blockFetchPipelinedBenchClient ::
+  -- | batchSize
+  Int ->
+  -- | maxInFlight (K)
+  Int ->
+  ClientState ->
+  ClientPipelined (BlockFetch (Serialised Blk) (Point Blk)) BFIdle IO ()
+blockFetchPipelinedBenchClient batchSize maxInFlight st =
+  ClientPipelined (sender Zero 0)
  where
-  nextRequest :: IO (BlockFetchRequest (Serialised Blk) (Point Blk) IO ())
-  nextRequest = do
-    decision <- atomically $ do
-      stopped <- readTVar (csStop st)
-      reachedTip <- readTVar (csReachedTip st)
-      qLen <- lengthTBQueue (csHeaderQ st)
-      let qLenI = fromIntegral qLen :: Int
-      if stopped
-        then pure Stop
-        else
-          if qLenI >= batchSize
-            then Fetch <$> drainN batchSize
-            else
-              if reachedTip
-                then
-                  if qLenI > 0
-                    then Fetch <$> drainN qLenI
-                    else pure Stop
-                else retry
-    case decision of
-      Stop -> pure (SendMsgClientDone ())
-      Fetch [] -> pure (SendMsgClientDone ()) -- unreachable: drainN only called when qLenI > 0
-      Fetch pts@(from_ : _) -> do
-        let to_ = lastOf pts from_
-        pure $
-          SendMsgRequestRange
-            (ChainRange from_ to_)
-            response
-            (BlockFetchClient nextRequest)
+  -- The 'Nat n' singleton tracks outstanding requests at the type level so
+  -- we may legally 'Collect' (only allowed when n ≥ 1) and 'Done' (only
+  -- allowed when n = 0). The 'Int' shadow is just so we can compare against
+  -- 'maxInFlight' without an O(n) singleton-to-Int conversion every step.
+  sender ::
+    forall n.
+    Nat n ->
+    Int ->
+    Client
+      (BlockFetch (Serialised Blk) (Point Blk))
+      ('Pipelined n ())
+      'BFIdle
+      IO
+      ()
+  sender outstanding inFlight = Effect $ do
+    decision <- atomically (decide inFlight)
+    pure (apply outstanding inFlight decision)
+
+  decide :: Int -> STM StepAction
+  decide inFlight = do
+    stopped <- readTVar (csStop st)
+    qLen <- lengthTBQueue (csHeaderQ st)
+    reachedTip <- readTVar (csReachedTip st)
+    let qLenI = fromIntegral qLen :: Int
+        canSend = inFlight < maxInFlight
+        haveOutstanding = inFlight > 0
+    if stopped
+      then
+        if haveOutstanding
+          then pure StepCollect -- drain the pipeline before terminating
+          else pure StepDone
+      else
+        if canSend && qLenI >= batchSize
+          then StepSend <$> drainN batchSize
+          else
+            if canSend && reachedTip && qLenI > 0
+              then StepSend <$> drainN qLenI
+              else
+                if haveOutstanding
+                  then pure StepCollect
+                  else
+                    if reachedTip
+                      then pure StepDone -- nothing in flight, nothing to send, server idle
+                      else retry -- block waiting for ChainSync to deliver more headers
+
+  apply ::
+    forall n.
+    Nat n ->
+    Int ->
+    StepAction ->
+    Client
+      (BlockFetch (Serialised Blk) (Point Blk))
+      ('Pipelined n ())
+      'BFIdle
+      IO
+      ()
+  apply outstanding _inFlight StepDone =
+    case outstanding of
+      Zero -> Yield MsgClientDone (Done ())
+      Succ _ -> error "gsa-bench: StepDone with outstanding > 0 should be impossible"
+  apply outstanding inFlight (StepSend pts) =
+    YieldPipelined
+      (MsgRequestRange (ChainRange (head pts) (lastOf pts (head pts))))
+      (receiver pts)
+      (sender (Succ outstanding) (inFlight + 1))
+  apply outstanding inFlight StepCollect =
+    case outstanding of
+      Zero ->
+        error "gsa-bench: StepCollect with no outstanding requests should be impossible"
+      Succ n ->
+        Collect
+          Nothing
+          (\() -> sender n (inFlight - 1))
+
+  receiver ::
+    [Point Blk] ->
+    Receiver
+      (BlockFetch (Serialised Blk) (Point Blk))
+      'BFBusy
+      'BFIdle
+      IO
+      ()
+  receiver _pts =
+    ReceiverAwait $ \case
+      MsgStartBatch -> receiveBlocks
+      MsgNoBlocks -> ReceiverDone ()
+   where
+    receiveBlocks ::
+      Receiver
+        (BlockFetch (Serialised Blk) (Point Blk))
+        'BFStreaming
+        'BFIdle
+        IO
+        ()
+    receiveBlocks =
+      ReceiverAwait $ \case
+        MsgBlock (Serialised bs) -> ReceiverEffect $ do
+          atomically $ addBlock (csCounter st) (fromIntegral (BL.length bs))
+          pure receiveBlocks
+        MsgBatchDone -> ReceiverDone ()
 
   -- Total replacement for @last@ — non-partial, requires a default.
   lastOf :: [a] -> a -> a
@@ -372,23 +465,7 @@ blockFetchBenchClient batchSize st = BlockFetchClient nextRequest
   drainN :: Int -> STM [Point Blk]
   drainN n = replicateM n (readTBQueue (csHeaderQ st))
 
-  response :: BlockFetchResponse (Serialised Blk) IO ()
-  response =
-    BlockFetchResponse
-      { handleStartBatch = pure receiver
-      , handleNoBlocks = pure ()
-      }
-
-  receiver :: BlockFetchReceiver (Serialised Blk) IO
-  receiver =
-    BlockFetchReceiver
-      { handleBlock = \(Serialised bs) -> do
-          atomically $ addBlock (csCounter st) (fromIntegral (BL.length bs))
-          pure receiver
-      , handleBatchDone = pure ()
-      }
-
-data FetchDecision = Stop | Fetch ![Point Blk]
+data StepAction = StepDone | StepSend ![Point Blk] | StepCollect
 
 -- ----- KeepAlive / TxSubmission stubs ----------------------------------------
 
@@ -410,7 +487,9 @@ noopKeepAliveClient = KeepAliveClient (atomically retry)
 -- blockFetch/txSubmission), using the same numbers, limits, and serialised
 -- codecs.
 benchApplication ::
-  -- | batchSize (passed through to blockFetchBenchClient)
+  -- | batchSize (passed through to blockFetchPipelinedBenchClient)
+  Int ->
+  -- | maxInFlight (pipeline depth on the BlockFetch protocol)
   Int ->
   TopLevelConfig Blk ->
   ClientState ->
@@ -425,7 +504,7 @@ benchApplication ::
         ()
         Void
     )
-benchApplication batchSize cfg st =
+benchApplication batchSize maxInFlight cfg st =
   Versions $ Map.mapWithKey mkVersion (supportedNodeToNodeVersions (Proxy @Blk))
  where
   networkMagic :: NetworkMagic
@@ -462,11 +541,11 @@ benchApplication batchSize cfg st =
               (chainSyncClientPeer (chainSyncBenchClient st))
       , mkMP Mux.StartEagerly N2N.blockFetchMiniProtocolNum blockFetchLims $
           MiniProtocolCb $ \_ctx channel ->
-            runPeer
+            runPipelinedPeer
               nullTracer
               cBlockFetchCodecSerialised
               channel
-              (blockFetchClientPeer (blockFetchBenchClient batchSize st))
+              (blockFetchPipelinedBenchClient batchSize maxInFlight st)
       , mkMP Mux.StartOnDemand N2N.txSubmissionMiniProtocolNum txSubmissionLims $
           MiniProtocolCb (\_ _ -> atomically retry)
       ]
@@ -502,17 +581,19 @@ benchApplication batchSize cfg st =
 runBenchClient ::
   -- | batchSize
   Int ->
+  -- | maxInFlight
+  Int ->
   Snocket.Snocket IO Socket.Socket Socket.SockAddr ->
   TopLevelConfig Blk ->
   Socket.SockAddr ->
   ClientState ->
   IO ()
-runBenchClient batchSize sn cfg addr st = do
+runBenchClient batchSize maxInFlight sn cfg addr st = do
   result <-
     N2N.connectTo
       sn
       N2N.nullNetworkConnectTracers
-      (benchApplication batchSize cfg st)
+      (benchApplication batchSize maxInFlight cfg st)
       Nothing
       addr
   case result of
@@ -669,6 +750,9 @@ main = withStdTerminalHandles $ do
   when (oParallel opts < 1) $ do
     hPutStrLn stderr "--parallel must be >= 1"
     exitFailure
+  when (oMaxInFlight opts < 1 || oMaxInFlight opts > 100) $ do
+    hPutStrLn stderr "--max-in-flight must be in [1, 100] (cap matches blockFetchPipeliningMax)"
+    exitFailure
   cfg <- getTopLevelConfig (oNodeConfig opts)
   addr <- resolveAddr (oHost opts) (oPort opts)
   hPutStrLn stderr $
@@ -678,6 +762,10 @@ main = withStdTerminalHandles $ do
       <> show (oPort opts)
       <> " parallel="
       <> show (oParallel opts)
+      <> " max-in-flight="
+      <> show (oMaxInFlight opts)
+      <> " batch-size="
+      <> show (oBatchSize opts)
 
   IOManager.withIOManager $ \iocp -> do
     let sn = Snocket.socketSnocket iocp
@@ -687,7 +775,10 @@ main = withStdTerminalHandles $ do
       sequence
         [ newClientCounter | _ <- [1 .. oParallel opts]
         ]
-    states <- traverse (\c -> newClientState c stop (oBatchSize opts)) counters
+    states <-
+      traverse
+        (\c -> newClientState c stop (oBatchSize opts) (oMaxInFlight opts))
+        counters
 
     start <- getCurrentTime
 
@@ -706,7 +797,9 @@ main = withStdTerminalHandles $ do
     link watchdogThread
 
     clientThreads :: [Async ()] <-
-      traverse (async . runBenchClient (oBatchSize opts) sn cfg addr) states
+      traverse
+        (async . runBenchClient (oBatchSize opts) (oMaxInFlight opts) sn cfg addr)
+        states
     for_ clientThreads link
 
     mapM_ wait clientThreads

--- a/tools/gsa-bench.hs
+++ b/tools/gsa-bench.hs
@@ -1,0 +1,732 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Synthetic Cardano node-to-node client that pulls blocks from a running GSA
+-- as fast as possible and reports throughput.
+--
+-- Drives ChainSync to track the server's tip and BlockFetch to stream block
+-- ranges in realistic batches, mirroring what a real cardano-node does but
+-- without any chain validation, header reconstruction, or consensus logic.
+-- Payload bytes are counted via @BL.length@ on the @Serialised blk@ CBOR
+-- wrapper — so the benchmark is schema-independent.
+module Main (main) where
+
+import Cardano.Crypto.Init (cryptoInit)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async, cancel, link, wait)
+import Control.Concurrent.STM
+  ( STM
+  , TBQueue
+  , TVar
+  , atomically
+  , lengthTBQueue
+  , modifyTVar'
+  , newTBQueueIO
+  , newTVarIO
+  , readTBQueue
+  , readTVar
+  , readTVarIO
+  , retry
+  , writeTBQueue
+  , writeTVar
+  )
+import Control.Exception (displayException)
+import Control.Monad (replicateM, unless, when)
+import qualified Data.ByteString.Lazy as BL
+import Data.Foldable (for_)
+import Data.List (intercalate)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock
+  ( UTCTime
+  , diffUTCTime
+  , getCurrentTime
+  )
+import Data.Void (Void)
+import Data.Word (Word64)
+import GenesisSyncAccelerator.Util (getTopLevelConfig)
+import Main.Utf8 (withStdTerminalHandles)
+import qualified Network.Mux as Mux
+import Network.Socket (HostName, PortNumber)
+import qualified Network.Socket as Socket
+import Options.Applicative
+import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.Cardano.Block (CardanoBlock, StandardCrypto)
+import Ouroboros.Consensus.Config
+import Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
+import qualified Ouroboros.Consensus.Network.NodeToNode as Consensus.N2N
+import Ouroboros.Consensus.Node (stdVersionDataNTN)
+import Ouroboros.Consensus.Node.NetworkProtocolVersion
+  ( supportedNodeToNodeVersions
+  )
+import Ouroboros.Network.Block
+  ( Serialised (..)
+  , Tip (..)
+  , getTipPoint
+  )
+import qualified Ouroboros.Network.IOManager as IOManager
+import Ouroboros.Network.Magic (NetworkMagic)
+import Ouroboros.Network.Driver.Simple (runPeer)
+import Ouroboros.Network.Mux
+  ( MiniProtocol (..)
+  , MiniProtocolCb (..)
+  , OuroborosApplication (..)
+  , OuroborosApplicationWithMinimalCtx
+  , RunMiniProtocol (..)
+  , mkMiniProtocolCbFromPeer
+  )
+import Ouroboros.Network.NodeToNode (NodeToNodeVersion, NodeToNodeVersionData)
+import qualified Ouroboros.Network.NodeToNode as N2N
+import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import Ouroboros.Network.PeerSelection.PeerSharing.Codec
+  ( decodeRemoteAddress
+  , encodeRemoteAddress
+  )
+import Ouroboros.Network.Protocol.BlockFetch.Client
+  ( BlockFetchClient (..)
+  , BlockFetchReceiver (..)
+  , BlockFetchRequest (..)
+  , BlockFetchResponse (..)
+  , blockFetchClientPeer
+  )
+import Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
+import Ouroboros.Network.Protocol.ChainSync.Client
+  ( ChainSyncClient (..)
+  , ClientStIdle (..)
+  , ClientStIntersect (..)
+  , ClientStNext (..)
+  , chainSyncClientPeer
+  )
+import Ouroboros.Network.Protocol.Handshake.Version (Version (..), Versions (..))
+import Ouroboros.Network.Protocol.KeepAlive.Client
+  ( KeepAliveClient (..)
+  , keepAliveClientPeer
+  )
+import qualified Ouroboros.Network.Snocket as Snocket
+import System.Exit (exitFailure)
+import System.IO (BufferMode (..), hPutStrLn, hSetBuffering, stderr, stdout)
+import "contra-tracer" Control.Tracer (nullTracer)
+
+-- ─── CLI ──────────────────────────────────────────────────────────────────────
+
+data Opts = Opts
+  { oHost :: HostName
+  , oPort :: PortNumber
+  , oNodeConfig :: FilePath
+  , oParallel :: Int
+  , oMaxBlocks :: Maybe Word64
+  , oDuration :: Maybe Double
+  , oReportInterval :: Double
+  , oBatchSize :: Int
+  }
+
+optsParser :: ParserInfo Opts
+optsParser =
+  info (helper <*> parse) $ fullDesc <> progDesc desc
+ where
+  desc =
+    "Drive ChainSync+BlockFetch against a running GSA and report blocks/s, MB/s"
+
+  parse = do
+    oHost <-
+      strOption $
+        long "host"
+          <> help "GSA host (default 127.0.0.1)"
+          <> metavar "HOST"
+          <> value "127.0.0.1"
+          <> showDefault
+    oPort <-
+      option (auto @Word64 >>= pure . fromIntegral) $
+        long "port"
+          <> help "GSA port (default 3001)"
+          <> metavar "PORT"
+          <> value 3001
+          <> showDefault
+    oNodeConfig <-
+      strOption $
+        long "node-config"
+          <> help "Path to Cardano node config JSON (same file the GSA reads)"
+          <> metavar "PATH"
+    oParallel <-
+      option auto $
+        long "parallel"
+          <> help "Number of concurrent fake-node connections (default 1)"
+          <> metavar "N"
+          <> value 1
+          <> showDefault
+    oMaxBlocks <-
+      optional $
+        option auto $
+          long "max-blocks"
+            <> help "Stop after receiving this many blocks (aggregate)"
+            <> metavar "N"
+    oDuration <-
+      optional $
+        option auto $
+          long "duration"
+            <> help "Stop after this many seconds of wall time"
+            <> metavar "SECS"
+    oReportInterval <-
+      option auto $
+        long "report-interval"
+          <> help "Seconds between progress lines (default 5)"
+          <> metavar "SECS"
+          <> value 5
+          <> showDefault
+    oBatchSize <-
+      option auto $
+        long "batch-size"
+          <> help "Points per BlockFetch MsgRequestRange (default 500)"
+          <> metavar "N"
+          <> value 500
+          <> showDefault
+    pure Opts{..}
+
+-- ─── Stats ───────────────────────────────────────────────────────────────────
+
+-- | Per-client counter. Each client mutates only its own counter; the reporter
+-- reads all counters and sums. Keeps the hot path contention-free.
+data ClientCounter = ClientCounter
+  { ccBlocks :: !(TVar Word64)
+  , ccBytes :: !(TVar Word64)
+  }
+
+newClientCounter :: IO ClientCounter
+newClientCounter = ClientCounter <$> newTVarIO 0 <*> newTVarIO 0
+
+addBlock :: ClientCounter -> Word64 -> STM ()
+addBlock ClientCounter{ccBlocks, ccBytes} nBytes = do
+  modifyTVar' ccBlocks (+ 1)
+  modifyTVar' ccBytes (+ nBytes)
+
+readCounter :: ClientCounter -> STM (Word64, Word64)
+readCounter ClientCounter{ccBlocks, ccBytes} =
+  (,) <$> readTVar ccBlocks <*> readTVar ccBytes
+
+aggregate :: [ClientCounter] -> STM (Word64, Word64)
+aggregate = foldr step (pure (0, 0))
+ where
+  step c acc = do
+    (bA, byA) <- acc
+    (b, by) <- readCounter c
+    pure (bA + b, byA + by)
+
+-- ─── Protocol client glue ────────────────────────────────────────────────────
+
+-- | Type alias to keep signatures short: the Cardano block the GSA serves.
+type Blk = CardanoBlock StandardCrypto
+
+-- | Shared state for one client connection.
+data ClientState = ClientState
+  { csCounter :: !ClientCounter
+  , csStop :: !(TVar Bool)
+  -- ^ Global stop flag (set by watchdog or max-blocks check).
+  , csServerTip :: !(TVar (Point Blk))
+  -- ^ Latest tip reported by the server over ChainSync. Updated by the
+  -- ChainSync client thread, read by the BlockFetch client thread.
+  , csHeaderQ :: !(TBQueue (Point Blk))
+  -- ^ Bounded queue of block 'Point's extracted from each @MsgRollForward@
+  -- header, pumped by ChainSync and drained by BlockFetch in batches. Acts
+  -- as backpressure — when BlockFetch falls behind, ChainSync blocks on
+  -- 'writeTBQueue' until drained.
+  , csReachedTip :: !(TVar Bool)
+  -- ^ Flipped to 'True' when the ChainSync server sends 'MsgAwaitReply'
+  -- (i.e. we're at the server's current tip). BlockFetch uses this as the
+  -- signal to drain any final partial batch and then send 'MsgClientDone'.
+  }
+
+newClientState :: ClientCounter -> TVar Bool -> Int -> IO ClientState
+newClientState counter stop batchSize = do
+  tip <- newTVarIO GenesisPoint
+  let cap = fromIntegral (max 2048 (4 * batchSize))
+  q <- newTBQueueIO cap
+  reachedTip <- newTVarIO False
+  pure
+    ClientState
+      { csCounter = counter
+      , csStop = stop
+      , csServerTip = tip
+      , csHeaderQ = q
+      , csReachedTip = reachedTip
+      }
+
+-- ----- ChainSync client: extract Points, track the tip ----------------------
+--
+-- On connection we @MsgFindIntersect [Genesis]@ to anchor at the start of
+-- chain. Each following @MsgRollForward@ delivers a typed 'Header Blk' from
+-- which we derive the block's 'Point' via 'blockPoint' (+ 'castPoint' to land
+-- in @Point Blk@). Points are pushed onto a bounded TBQueue that BlockFetch
+-- drains in batches. If BlockFetch falls behind, the queue fills and
+-- 'writeTBQueue' blocks — natural backpressure that gates ChainSync.
+
+chainSyncBenchClient ::
+  ClientState ->
+  ChainSyncClient (Header Blk) (Point Blk) (Tip Blk) IO ()
+chainSyncBenchClient st =
+  ChainSyncClient $ pure $
+    SendMsgFindIntersect [GenesisPoint] intersect
+ where
+  updateTipThen :: Tip Blk -> ChainSyncClient (Header Blk) (Point Blk) (Tip Blk) IO ()
+  updateTipThen tip = ChainSyncClient $ do
+    atomically $ writeTVar (csServerTip st) (getTipPoint tip)
+    runChainSyncClient requestLoop
+
+  intersect =
+    ClientStIntersect
+      { recvMsgIntersectFound = \_pt tip -> updateTipThen tip
+      , recvMsgIntersectNotFound = updateTipThen
+      }
+
+  requestLoop :: ChainSyncClient (Header Blk) (Point Blk) (Tip Blk) IO ()
+  requestLoop = ChainSyncClient $ do
+    stopped <- readTVarIO (csStop st)
+    if stopped
+      then pure (SendMsgDone ())
+      else
+        -- The @pure@ slot in 'SendMsgRequestNext' fires *exactly* when the
+        -- server sends 'MsgAwaitReply', i.e. the server is stuck at tip.
+        -- BlockFetch reads 'csReachedTip' to know "no more points coming,
+        -- drain any remainder and close".
+        pure $
+          SendMsgRequestNext
+            (atomically $ writeTVar (csReachedTip st) True)
+            stNext
+
+  stNext :: ClientStNext (Header Blk) (Point Blk) (Tip Blk) IO ()
+  stNext =
+    ClientStNext
+      { recvMsgRollForward = \hdr tip -> ChainSyncClient $ do
+          let pt = castPoint (blockPoint hdr) :: Point Blk
+          atomically $ do
+            writeTVar (csServerTip st) (getTipPoint tip)
+            writeTBQueue (csHeaderQ st) pt
+          runChainSyncClient requestLoop
+      , recvMsgRollBackward = \_pt tip -> updateTipThen tip
+        -- Rollbacks in practice only happen once (server rolls us back to
+        -- the negotiated Genesis intersection), and our queue is empty at
+        -- that point, so no draining needed. For a real mid-chain rollback
+        -- we'd need to remove any queued Points strictly after @_pt@, but
+        -- that case doesn't occur when benching against an ImmutableDB.
+      }
+
+-- ----- BlockFetch client: batched range requests -----------------------------
+--
+-- Drain up to @batchSize@ 'Point's from 'csHeaderQ', form a
+-- @ChainRange (firstPoint, lastPoint)@ covering them, and issue a single
+-- 'MsgRequestRange'. The server responds with 'MsgStartBatch' followed by one
+-- 'MsgBlock' per point then 'MsgBatchDone'. We count bytes per received block.
+-- One round-trip per batch amortises RTT overhead across @batchSize@ blocks.
+
+blockFetchBenchClient :: Int -> ClientState -> BlockFetchClient (Serialised Blk) (Point Blk) IO ()
+blockFetchBenchClient batchSize st = BlockFetchClient nextRequest
+ where
+  nextRequest :: IO (BlockFetchRequest (Serialised Blk) (Point Blk) IO ())
+  nextRequest = do
+    decision <- atomically $ do
+      stopped <- readTVar (csStop st)
+      reachedTip <- readTVar (csReachedTip st)
+      qLen <- lengthTBQueue (csHeaderQ st)
+      let qLenI = fromIntegral qLen :: Int
+      if stopped
+        then pure Stop
+        else
+          if qLenI >= batchSize
+            then Fetch <$> drainN batchSize
+            else
+              if reachedTip
+                then
+                  if qLenI > 0
+                    then Fetch <$> drainN qLenI
+                    else pure Stop
+                else retry
+    case decision of
+      Stop -> pure (SendMsgClientDone ())
+      Fetch [] -> pure (SendMsgClientDone ())  -- unreachable: drainN only called when qLenI > 0
+      Fetch pts@(from_ : _) -> do
+        let to_ = lastOf pts from_
+        pure $
+          SendMsgRequestRange
+            (ChainRange from_ to_)
+            response
+            (BlockFetchClient nextRequest)
+
+  -- Total replacement for @last@ — non-partial, requires a default.
+  lastOf :: [a] -> a -> a
+  lastOf []       d = d
+  lastOf [x]      _ = x
+  lastOf (_ : xs) d = lastOf xs d
+
+  drainN :: Int -> STM [Point Blk]
+  drainN n = replicateM n (readTBQueue (csHeaderQ st))
+
+  response :: BlockFetchResponse (Serialised Blk) IO ()
+  response =
+    BlockFetchResponse
+      { handleStartBatch = pure receiver
+      , handleNoBlocks = pure ()
+      }
+
+  receiver :: BlockFetchReceiver (Serialised Blk) IO
+  receiver =
+    BlockFetchReceiver
+      { handleBlock = \(Serialised bs) -> do
+          atomically $ addBlock (csCounter st) (fromIntegral (BL.length bs))
+          pure receiver
+      , handleBatchDone = pure ()
+      }
+
+data FetchDecision = Stop | Fetch ![Point Blk]
+
+-- ----- KeepAlive / TxSubmission stubs ----------------------------------------
+
+-- | Keep-alive client that never pings and never terminates.
+--
+-- Critical subtlety: 'simpleMuxCallback' (what 'connectTo' uses internally)
+-- waits for the *first* mini-protocol to finish and then cancels the rest.
+-- A KeepAliveClient that returns 'SendMsgDone' ends up finishing immediately,
+-- taking ChainSync and BlockFetch with it (AsyncCancelled). So we block
+-- forever here; Mux never schedules any bytes for this protocol, and the
+-- server-side @StartOnDemandAny@ responder stays idle too.
+noopKeepAliveClient :: KeepAliveClient IO ()
+noopKeepAliveClient = KeepAliveClient (atomically retry)
+
+-- ─── Wire assembly ───────────────────────────────────────────────────────────
+
+-- | Build the full initiator-side 'OuroborosApplication' for one connection.
+-- Mirrors the four mini-protocols the GSA serves (keepAlive/chainSync/
+-- blockFetch/txSubmission), using the same numbers, limits, and serialised
+-- codecs.
+benchApplication ::
+  Int ->
+  -- ^ batchSize (passed through to blockFetchBenchClient)
+  TopLevelConfig Blk ->
+  ClientState ->
+  Versions
+    NodeToNodeVersion
+    NodeToNodeVersionData
+    ( OuroborosApplicationWithMinimalCtx
+        'Mux.InitiatorMode
+        Socket.SockAddr
+        BL.ByteString
+        IO
+        ()
+        Void
+    )
+benchApplication batchSize cfg st =
+  Versions $ Map.mapWithKey mkVersion (supportedNodeToNodeVersions (Proxy @Blk))
+ where
+  networkMagic :: NetworkMagic
+  networkMagic = getNetworkMagic (configBlock cfg)
+
+  versionData =
+    stdVersionDataNTN
+      networkMagic
+      N2N.InitiatorOnlyDiffusionMode
+      PeerSharingDisabled
+
+  codecCfg = configCodec cfg
+
+  mkVersion version blockVersion =
+    Version
+      { versionApplication = const (application version blockVersion)
+      , versionData
+      }
+
+  application version blockVersion =
+    OuroborosApplication
+      [ mkMP Mux.StartOnDemand N2N.keepAliveMiniProtocolNum keepAliveLims $
+          mkMiniProtocolCbFromPeer $ \_ctx ->
+            ( nullTracer
+            , cKeepAliveCodec
+            , keepAliveClientPeer noopKeepAliveClient
+            )
+      , mkMP Mux.StartEagerly N2N.chainSyncMiniProtocolNum chainSyncLims $
+          MiniProtocolCb $ \_ctx channel ->
+            runPeer
+              nullTracer
+              cChainSyncCodec
+              channel
+              (chainSyncClientPeer (chainSyncBenchClient st))
+      , mkMP Mux.StartEagerly N2N.blockFetchMiniProtocolNum blockFetchLims $
+          MiniProtocolCb $ \_ctx channel ->
+            runPeer
+              nullTracer
+              cBlockFetchCodecSerialised
+              channel
+              (blockFetchClientPeer (blockFetchBenchClient batchSize st))
+      , mkMP Mux.StartOnDemand N2N.txSubmissionMiniProtocolNum txSubmissionLims $
+          MiniProtocolCb (\_ _ -> atomically retry)
+      ]
+   where
+    Consensus.N2N.Codecs
+      { Consensus.N2N.cKeepAliveCodec
+      , Consensus.N2N.cChainSyncCodec
+      , Consensus.N2N.cBlockFetchCodecSerialised
+      } =
+        Consensus.N2N.defaultCodecs
+          codecCfg
+          blockVersion
+          encodeRemoteAddress
+          decodeRemoteAddress
+          version
+
+  params = N2N.defaultMiniProtocolParameters
+  keepAliveLims = N2N.keepAliveProtocolLimits params
+  chainSyncLims = N2N.chainSyncProtocolLimits params
+  blockFetchLims = N2N.blockFetchProtocolLimits params
+  txSubmissionLims = N2N.txSubmissionProtocolLimits params
+
+  mkMP start num lims run =
+    MiniProtocol
+      { miniProtocolNum = num
+      , miniProtocolStart = start
+      , miniProtocolLimits = lims
+      , miniProtocolRun = InitiatorProtocolOnly run
+      }
+
+-- ─── Client runner ───────────────────────────────────────────────────────────
+
+runBenchClient ::
+  Int ->
+  -- ^ batchSize
+  Snocket.Snocket IO Socket.Socket Socket.SockAddr ->
+  TopLevelConfig Blk ->
+  Socket.SockAddr ->
+  ClientState ->
+  IO ()
+runBenchClient batchSize sn cfg addr st = do
+  result <-
+    N2N.connectTo
+      sn
+      N2N.nullNetworkConnectTracers
+      (benchApplication batchSize cfg st)
+      Nothing
+      addr
+  case result of
+    Left e -> do
+      hPutStrLn stderr $ "[gsa-bench] client failed: " <> displayException e
+      -- Any client failure flips the stop flag so the rest of the benchmark
+      -- reports its terminal numbers and shuts down.
+      atomically $ writeTVar (csStop st) True
+    Right _ -> pure ()
+
+-- ─── Reporter & watchdog ─────────────────────────────────────────────────────
+
+data Snapshot = Snapshot
+  { snapAt :: !UTCTime
+  , snapBlocks :: !Word64
+  , snapBytes :: !Word64
+  }
+
+snapshot :: [ClientCounter] -> IO Snapshot
+snapshot counters = do
+  (b, by) <- atomically (aggregate counters)
+  now <- getCurrentTime
+  pure (Snapshot now b by)
+
+reporter :: Double -> UTCTime -> [ClientCounter] -> TVar Bool -> IO ()
+reporter intervalSecs start counters stop = do
+  hSetBuffering stdout LineBuffering
+  loop =<< snapshot counters
+ where
+  intervalMicros = round (intervalSecs * 1_000_000)
+
+  loop prev = do
+    stopped <- readTVarIO stop
+    if stopped
+      then pure ()
+      else do
+        threadDelay intervalMicros
+        cur <- snapshot counters
+        let dt = realToFrac (diffUTCTime (snapAt cur) (snapAt prev)) :: Double
+            total = realToFrac (diffUTCTime (snapAt cur) start) :: Double
+            db = snapBlocks cur - snapBlocks prev
+            dby = snapBytes cur - snapBytes prev
+            bps = if dt > 0 then fromIntegral db / dt else 0 :: Double
+            mbps = if dt > 0 then fromIntegral dby / dt / 1_048_576 else 0 :: Double
+        putStrLn $
+          concat
+            [ "[t=" ++ formatDouble 6 1 total ++ "s] "
+            , "blocks=" ++ show (snapBlocks cur)
+            , " (+" ++ show db ++ "  " ++ formatDouble 10 1 bps ++ "/s)  "
+            , "bytes=" ++ formatBytes (snapBytes cur)
+            , " (+" ++ formatBytes dby ++ "  " ++ formatDouble 10 2 mbps ++ " MB/s)"
+            ]
+        loop cur
+
+watchdog ::
+  Maybe Word64 ->
+  Maybe Double ->
+  UTCTime ->
+  [ClientCounter] ->
+  TVar Bool ->
+  IO ()
+watchdog mMaxBlocks mDuration start counters stop = loop
+ where
+  pollMicros = 200_000
+
+  loop = do
+    stopped <- readTVarIO stop
+    unless stopped $ do
+      (b, _) <- atomically (aggregate counters)
+      now <- getCurrentTime
+      let elapsed = realToFrac (diffUTCTime now start) :: Double
+          hitBlocks = maybe False (b >=) mMaxBlocks
+          hitTime = maybe False (elapsed >=) mDuration
+      if hitBlocks || hitTime
+        then atomically (writeTVar stop True)
+        else do
+          threadDelay pollMicros
+          loop
+
+-- ─── Formatting helpers ─────────────────────────────────────────────────────
+
+formatDouble :: Int -> Int -> Double -> String
+formatDouble width decimals x =
+  let s = showFFixed decimals x
+   in replicate (max 0 (width - length s)) ' ' ++ s
+ where
+  showFFixed d n =
+    let factor = 10 ^^ d :: Double
+        rounded = fromIntegral (round (n * factor) :: Integer) / factor :: Double
+     in showWithDecimals d rounded
+  showWithDecimals d n
+    | d <= 0 = show (truncate n :: Integer)
+    | otherwise =
+        let whole = truncate n :: Integer
+            frac = abs (n - fromIntegral whole)
+            fracStr = take d (drop 2 (show (frac + 1))) -- "1.12345" -> "12345"
+         in show whole ++ "." ++ pad d fracStr
+  pad d s = s ++ replicate (d - length s) '0'
+
+formatBytes :: Word64 -> String
+formatBytes n
+  | n < k = show n ++ " B"
+  | n < m = formatDouble 0 2 (fromIntegral n / fromIntegral k) ++ " KB"
+  | n < g = formatDouble 0 2 (fromIntegral n / fromIntegral m) ++ " MB"
+  | n < t = formatDouble 0 2 (fromIntegral n / fromIntegral g) ++ " GB"
+  | otherwise = formatDouble 0 2 (fromIntegral n / fromIntegral t) ++ " TB"
+ where
+  k = 1_024 :: Word64
+  m = k * 1_024
+  g = m * 1_024
+  t = g * 1_024
+
+-- Escape a string value for our minimal JSON emitter.
+jsonString :: String -> String
+jsonString s = '"' : concatMap esc s ++ "\""
+ where
+  esc '"' = "\\\""
+  esc '\\' = "\\\\"
+  esc c = [c]
+
+finalSummary ::
+  UTCTime ->
+  Int ->
+  [ClientCounter] ->
+  IO ()
+finalSummary start clients counters = do
+  (b, by) <- atomically (aggregate counters)
+  now <- getCurrentTime
+  let dt = realToFrac (diffUTCTime now start) :: Double
+      bps = if dt > 0 then fromIntegral b / dt else 0 :: Double
+      mbps = if dt > 0 then fromIntegral by / dt / 1_048_576 else 0 :: Double
+  putStrLn $
+    "{"
+      <> intercalate
+        ","
+        [ pair "duration_s" (formatDouble 0 3 dt)
+        , pair "clients" (show clients)
+        , pair "blocks" (show b)
+        , pair "bytes" (show by)
+        , pair "blocks_per_sec" (formatDouble 0 3 bps)
+        , pair "mb_per_sec" (formatDouble 0 3 mbps)
+        ]
+      <> "}"
+ where
+  pair k v = jsonString k <> ":" <> v
+
+-- ─── Main ────────────────────────────────────────────────────────────────────
+
+main :: IO ()
+main = withStdTerminalHandles $ do
+  hSetBuffering stdout LineBuffering
+  cryptoInit
+  opts <- execParser optsParser
+  when (oParallel opts < 1) $ do
+    hPutStrLn stderr "--parallel must be >= 1"
+    exitFailure
+  cfg <- getTopLevelConfig (oNodeConfig opts)
+  addr <- resolveAddr (oHost opts) (oPort opts)
+  hPutStrLn stderr $
+    "[gsa-bench] target="
+      <> oHost opts
+      <> ":"
+      <> show (oPort opts)
+      <> " parallel="
+      <> show (oParallel opts)
+
+  IOManager.withIOManager $ \iocp -> do
+    let sn = Snocket.socketSnocket iocp
+
+    stop <- newTVarIO False
+    counters <-
+      sequence
+        [ newClientCounter | _ <- [1 .. oParallel opts]
+        ]
+    states <- traverse (\c -> newClientState c stop (oBatchSize opts)) counters
+
+    start <- getCurrentTime
+
+    reporterThread <- async (reporter (oReportInterval opts) start counters stop)
+    link reporterThread
+
+    watchdogThread <-
+      async
+        ( watchdog
+            (oMaxBlocks opts)
+            (oDuration opts)
+            start
+            counters
+            stop
+        )
+    link watchdogThread
+
+    clientThreads :: [Async ()] <-
+      traverse (async . runBenchClient (oBatchSize opts) sn cfg addr) states
+    for_ clientThreads link
+
+    mapM_ wait clientThreads
+    -- Clients done → ensure stop is flipped so the reporter wraps up.
+    atomically $ writeTVar stop True
+    cancel reporterThread
+    cancel watchdogThread
+
+    finalSummary start (oParallel opts) counters
+
+resolveAddr :: HostName -> PortNumber -> IO Socket.SockAddr
+resolveAddr host port = do
+  let hints =
+        Socket.defaultHints
+          { Socket.addrSocketType = Socket.Stream
+          , Socket.addrFamily = Socket.AF_INET
+          }
+  ais <- Socket.getAddrInfo (Just hints) (Just host) (Just (show port))
+  case ais of
+    (ai : _) -> pure (Socket.addrAddress ai)
+    [] -> do
+      hPutStrLn stderr $ "could not resolve host " <> host
+      exitFailure
+

--- a/tools/gsa-bench.hs
+++ b/tools/gsa-bench.hs
@@ -76,9 +76,9 @@ import Ouroboros.Network.Block
   , Tip (..)
   , getTipPoint
   )
+import Ouroboros.Network.Driver.Simple (runPeer)
 import qualified Ouroboros.Network.IOManager as IOManager
 import Ouroboros.Network.Magic (NetworkMagic)
-import Ouroboros.Network.Driver.Simple (runPeer)
 import Ouroboros.Network.Mux
   ( MiniProtocol (..)
   , MiniProtocolCb (..)
@@ -275,8 +275,9 @@ chainSyncBenchClient ::
   ClientState ->
   ChainSyncClient (Header Blk) (Point Blk) (Tip Blk) IO ()
 chainSyncBenchClient st =
-  ChainSyncClient $ pure $
-    SendMsgFindIntersect [GenesisPoint] intersect
+  ChainSyncClient $
+    pure $
+      SendMsgFindIntersect [GenesisPoint] intersect
  where
   updateTipThen :: Tip Blk -> ChainSyncClient (Header Blk) (Point Blk) (Tip Blk) IO ()
   updateTipThen tip = ChainSyncClient $ do
@@ -314,11 +315,11 @@ chainSyncBenchClient st =
             writeTBQueue (csHeaderQ st) pt
           runChainSyncClient requestLoop
       , recvMsgRollBackward = \_pt tip -> updateTipThen tip
-        -- Rollbacks in practice only happen once (server rolls us back to
-        -- the negotiated Genesis intersection), and our queue is empty at
-        -- that point, so no draining needed. For a real mid-chain rollback
-        -- we'd need to remove any queued Points strictly after @_pt@, but
-        -- that case doesn't occur when benching against an ImmutableDB.
+      -- Rollbacks in practice only happen once (server rolls us back to
+      -- the negotiated Genesis intersection), and our queue is empty at
+      -- that point, so no draining needed. For a real mid-chain rollback
+      -- we'd need to remove any queued Points strictly after @_pt@, but
+      -- that case doesn't occur when benching against an ImmutableDB.
       }
 
 -- ----- BlockFetch client: batched range requests -----------------------------
@@ -353,7 +354,7 @@ blockFetchBenchClient batchSize st = BlockFetchClient nextRequest
                 else retry
     case decision of
       Stop -> pure (SendMsgClientDone ())
-      Fetch [] -> pure (SendMsgClientDone ())  -- unreachable: drainN only called when qLenI > 0
+      Fetch [] -> pure (SendMsgClientDone ()) -- unreachable: drainN only called when qLenI > 0
       Fetch pts@(from_ : _) -> do
         let to_ = lastOf pts from_
         pure $
@@ -364,8 +365,8 @@ blockFetchBenchClient batchSize st = BlockFetchClient nextRequest
 
   -- Total replacement for @last@ — non-partial, requires a default.
   lastOf :: [a] -> a -> a
-  lastOf []       d = d
-  lastOf [x]      _ = x
+  lastOf [] d = d
+  lastOf [x] _ = x
   lastOf (_ : xs) d = lastOf xs d
 
   drainN :: Int -> STM [Point Blk]
@@ -409,8 +410,8 @@ noopKeepAliveClient = KeepAliveClient (atomically retry)
 -- blockFetch/txSubmission), using the same numbers, limits, and serialised
 -- codecs.
 benchApplication ::
+  -- | batchSize (passed through to blockFetchBenchClient)
   Int ->
-  -- ^ batchSize (passed through to blockFetchBenchClient)
   TopLevelConfig Blk ->
   ClientState ->
   Versions
@@ -499,8 +500,8 @@ benchApplication batchSize cfg st =
 -- ─── Client runner ───────────────────────────────────────────────────────────
 
 runBenchClient ::
+  -- | batchSize
   Int ->
-  -- ^ batchSize
   Snocket.Snocket IO Socket.Socket Socket.SockAddr ->
   TopLevelConfig Blk ->
   Socket.SockAddr ->
@@ -729,4 +730,3 @@ resolveAddr host port = do
     [] -> do
       hPutStrLn stderr $ "could not resolve host " <> host
       exitFailure
-


### PR DESCRIPTION
Introduces `gsa-bench` utility, whose goal is to "pull" from GSA as fast as possible, possibly running multiple streams in parallel, and returns throughput measurements. The goal is to validate that GSA has enough bandwidth headroom for `cardano-node` needs.

Also includes:
- sweep-matrix.sh which produces a CSV file of measurements from a matrix of configurations.
- A Python script for plutting bench results.



